### PR TITLE
[CU-86eu7npzg] Add one new command line option `--env` to set the specific file path to load environment variables

### DIFF
--- a/clickup_mcp/client.py
+++ b/clickup_mcp/client.py
@@ -391,32 +391,41 @@ def load_api_token_from_env(env_var_name: str = "CLICKUP_API_TOKEN", env_file: s
     return os.environ.get(env_var_name)
 
 
-# Convenience function to create a configured client
-def create_clickup_client(api_token: Optional[str] = None, **kwargs) -> ClickUpAPIClient:
+def get_api_token() -> str:
     """
-    Create a ClickUp API client with the provided token and optional configuration.
+    Get the ClickUp API token from environment variables.
     
-    If api_token is not provided, it will attempt to load it from the .env file
-    or from the CLICKUP_API_TOKEN environment variable.
-
-    Args:
-        api_token: ClickUp API token (optional if set in env vars or .env file)
-        **kwargs: Additional configuration options for the client
-
+    The .env file should be loaded at the entry point of the application.
+    
     Returns:
-        Configured ClickUpAPIClient instance
+        The API token if found
         
     Raises:
-        ValueError: If API token is not provided and not found in environment
+        ValueError: If API token cannot be found
     """
-    # If api_token is not provided, try to load from environment
-    if api_token is None:
-        api_token = load_api_token_from_env()
-        if not api_token:
-            raise ValueError(
-                "ClickUp API token not found. Please provide it as an argument, "
-                "set the CLICKUP_API_TOKEN environment variable, "
-                "or add it to your .env file."
-            )
+    # Get token directly from environment (env file should be loaded at entry point)
+    token = os.environ.get("CLICKUP_API_TOKEN")
     
+    # Raise error if we don't have a token
+    if not token:
+        raise ValueError(
+            "ClickUp API token not found. Please set the CLICKUP_API_TOKEN environment variable "
+            "in your .env file and ensure it is loaded."
+        )
+    
+    return token
+
+
+# Convenience function to create a configured client
+def create_clickup_client(api_token: str, **kwargs) -> ClickUpAPIClient:
+    """
+    Create a ClickUp API client with the provided token and configuration.
+    
+    Args:
+        api_token: ClickUp API token (required)
+        **kwargs: Additional configuration options for the client
+        
+    Returns:
+        Configured ClickUpAPIClient instance
+    """
     return ClickUpAPIClient(api_token=api_token, **kwargs)

--- a/clickup_mcp/entry.py
+++ b/clickup_mcp/entry.py
@@ -70,6 +70,18 @@ def run_server(config: ServerConfig) -> None:
     """
     configure_logging(config.log_level)
 
+    # Load environment variables from .env file
+    if config.env_file:
+        from pathlib import Path
+        from dotenv import load_dotenv
+        
+        env_path = Path(config.env_file)
+        if env_path.exists():
+            logging.info(f"Loading environment variables from {config.env_file}")
+            load_dotenv(env_path)
+        else:
+            logging.warning(f"Environment file {config.env_file} not found")
+
     # Create the FastAPI app
     app = create_app()
 

--- a/clickup_mcp/entry.py
+++ b/clickup_mcp/entry.py
@@ -7,6 +7,7 @@ that hosts the ClickUp MCP functionality.
 
 import argparse
 import logging
+import os
 import sys
 from typing import Dict, Optional, Union
 
@@ -32,6 +33,7 @@ def parse_args() -> ServerConfig:
         "--log-level", type=str, default="info", choices=[level.value for level in LogLevel], help="Logging level"
     )
     parser.add_argument("--reload", action="store_true", help="Enable auto-reload for development")
+    parser.add_argument("--env", type=str, dest="env_file", default=".env", help="Path to the .env file for environment variables")
 
     # Parse args into a dictionary
     args_namespace = parser.parse_args()
@@ -75,6 +77,7 @@ def run_server(config: ServerConfig) -> None:
     logging.info(f"Starting server on {config.host}:{config.port}")
     logging.info(f"Log level: {config.log_level}")
     logging.info(f"Auto-reload: {'enabled' if config.reload else 'disabled'}")
+    logging.info(f"Environment file: {config.env_file}")
 
     # Run the server
     uvicorn.run(app=app, host=config.host, port=config.port, log_level=config.log_level.lower(), reload=config.reload)
@@ -87,6 +90,8 @@ def create_app_factory() -> FastAPI:
     Returns:
         The FastAPI application
     """
+    # Note: When using reload, this function is called by Uvicorn, so we can't access CLI args
+    # For environment file, the default .env will be used
     return create_app()
 
 

--- a/clickup_mcp/mcp_server/app.py
+++ b/clickup_mcp/mcp_server/app.py
@@ -1,4 +1,21 @@
+from typing import Optional
+
 from mcp.server import FastMCP
 
-# Define the MCP server using FastMCP
-mcp = FastMCP()
+
+def create_mcp_server() -> FastMCP:
+    """
+    Create and configure the MCP server with the specified environment file.
+    
+    Args:
+        env_file: Path to the .env file for environment variables
+        
+    Returns:
+        Configured FastMCP server instance
+    """
+    # Create a new FastMCP instance
+    return FastMCP()
+
+
+# Create a default MCP server instance for backward compatibility
+mcp = create_mcp_server()

--- a/clickup_mcp/mcp_server/app.py
+++ b/clickup_mcp/mcp_server/app.py
@@ -7,9 +7,6 @@ def create_mcp_server() -> FastMCP:
     """
     Create and configure the MCP server with the specified environment file.
     
-    Args:
-        env_file: Path to the .env file for environment variables
-        
     Returns:
         Configured FastMCP server instance
     """

--- a/clickup_mcp/mcp_server/space.py
+++ b/clickup_mcp/mcp_server/space.py
@@ -7,13 +7,13 @@ These functions follow the FastMCP pattern for easy integration into MCP servers
 
 from typing import Optional
 
-from clickup_mcp.client import create_clickup_client
+from clickup_mcp.client import create_clickup_client, get_api_token
 
 from .app import mcp
 
 
 @mcp.tool(name="get_space", title="Get ClickUp Space", description="Get a ClickUp space by its ID.")
-async def get_space(api_token: str, space_id: str) -> Optional[dict]:
+async def get_space(space_id: str = "") -> Optional[dict]:
     """
     Get a ClickUp space by its ID.
 
@@ -21,23 +21,23 @@ async def get_space(api_token: str, space_id: str) -> Optional[dict]:
     the space domain model if found, or None if the space does not exist.
 
     Args:
-        api_token: The ClickUp API token to use for authentication.
         space_id: The ID of the space to retrieve.
 
     Returns:
         The ClickUpSpace domain model as a dictionary if found, or None if the space does not exist.
 
     Raises:
-        ValueError: If the API token is not provided or if the space ID is empty.
+        ValueError: If the API token is not found or if the space ID is empty.
     """
     # Validate inputs
-    if not api_token:
-        raise ValueError("API token is required")
     if not space_id:
         raise ValueError("Space ID is required")
+        
+    # Get API token from environment (which was loaded at application startup)
+    token = get_api_token()
 
-    # Create client
-    client = create_clickup_client(api_token)
+    # Create client with the token
+    client = create_clickup_client(api_token=token)
 
     try:
         # Get the space using the client

--- a/clickup_mcp/models/cli.py
+++ b/clickup_mcp/models/cli.py
@@ -31,6 +31,7 @@ class ServerConfig(BaseModel):
     port: int = Field(default=8000, description="Port to bind the server to", ge=1, le=65535)
     log_level: LogLevel = Field(default=LogLevel.INFO, description="Logging level")
     reload: bool = Field(default=False, description="Enable auto-reload for development")
+    env_file: str = Field(default=".env", description="Path to the .env file for environment variables")
 
     @validator("port")
     def validate_port_range(cls, v: int) -> int:

--- a/clickup_mcp/web_server/app.py
+++ b/clickup_mcp/web_server/app.py
@@ -12,17 +12,17 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from mcp.server import FastMCP
 
-from clickup_mcp.mcp_server.app import mcp as clickup_mcp
+from clickup_mcp.mcp_server.app import create_mcp_server
 
 
 def get_mcp_server() -> FastMCP:
     """
-    Get the MCP server instance.
+    Get the MCP server instance with the specified environment file.
 
     Returns:
         The configured MCP server instance
     """
-    return clickup_mcp
+    return create_mcp_server()
 
 
 def create_app() -> FastAPI:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pydantic>=2.11.7",
     "uvicorn>=0.35.0",
     "httpx>=0.27.0",
+    "python-dotenv>=1.0.0",
 ]
 
 [project.urls]

--- a/test/unit_test/test_cli_env_option.py
+++ b/test/unit_test/test_cli_env_option.py
@@ -1,0 +1,62 @@
+"""
+Tests for the CLI --env option functionality.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from clickup_mcp.entry import parse_args, run_server
+from clickup_mcp.models.cli import ServerConfig
+
+
+class TestCliEnvOption:
+    """Tests for the CLI --env option."""
+
+    def test_env_cli_parameter(self):
+        """Test parsing the --env CLI parameter."""
+        # Create a temporary env file path
+        temp_env_path = "/tmp/custom_test.env"
+        
+        # Simulate CLI args with --env
+        with patch("sys.argv", ["clickup_mcp", "--env", temp_env_path]):
+            config = parse_args()
+            assert isinstance(config, ServerConfig)
+            assert config.env_file == temp_env_path
+    
+    def test_env_file_loaded_in_run_server(self, monkeypatch):
+        """Test that the env file is loaded directly in run_server."""
+        # Create a temp .env file with a test token
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as temp_file:
+            temp_file.write("CLICKUP_API_TOKEN=test_token_from_cli_env\n")
+            env_path = temp_file.name
+            
+        try:
+            # Create a config with our temp env file
+            config = ServerConfig(env_file=env_path)
+            
+            # Ensure environment is clean
+            monkeypatch.delenv("CLICKUP_API_TOKEN", raising=False)
+            
+            # Mock create_app and uvicorn.run to prevent actual server startup
+            with patch("clickup_mcp.entry.create_app") as mock_create_app, \
+                patch("clickup_mcp.entry.uvicorn.run") as mock_run:
+                
+                # Run the server with our config
+                run_server(config)
+                
+                # Check that create_app was called (without env_file parameter)
+                mock_create_app.assert_called_once_with()
+                
+                # Verify the environment variable was loaded from the file
+                assert os.environ.get("CLICKUP_API_TOKEN") == "test_token_from_cli_env"
+                
+                # Verify uvicorn.run was called
+                assert mock_run.called
+                
+        finally:
+            # Clean up temp file
+            Path(env_path).unlink(missing_ok=True)

--- a/test/unit_test/test_env_loading.py
+++ b/test/unit_test/test_env_loading.py
@@ -1,0 +1,103 @@
+"""
+Tests for environment variable loading.
+"""
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from clickup_mcp.client import create_clickup_client, get_api_token, load_api_token_from_env
+
+
+class TestEnvLoading:
+    """Tests for environment variable loading functions."""
+
+    def test_load_api_token_from_env_with_default_env_file(self, monkeypatch):
+        """Test loading API token from default .env file."""
+        # Create a temporary .env file
+        with tempfile.NamedTemporaryFile(prefix=".env", delete=False) as temp_file:
+            temp_file.write(b"CLICKUP_API_TOKEN=test_token_from_env_file")
+        
+        try:
+            # Ensure environment is clean
+            monkeypatch.delenv("CLICKUP_API_TOKEN", raising=False)
+            
+            # Test loading from the temp file
+            token = load_api_token_from_env(env_file=temp_file.name)
+            assert token == "test_token_from_env_file"
+        finally:
+            # Clean up
+            Path(temp_file.name).unlink(missing_ok=True)
+
+    def test_load_api_token_from_env_with_custom_env_file(self, monkeypatch):
+        """Test loading API token from custom .env file."""
+        # Create a temporary custom .env file
+        with tempfile.NamedTemporaryFile(suffix=".env", delete=False) as temp_file:
+            temp_file.write(b"CLICKUP_API_TOKEN=test_token_from_custom_env_file")
+        
+        try:
+            # Ensure environment is clean
+            monkeypatch.delenv("CLICKUP_API_TOKEN", raising=False)
+            
+            # Test loading from the custom file directly
+            token = load_api_token_from_env(env_file=temp_file.name)
+            assert token == "test_token_from_custom_env_file"
+        finally:
+            # Clean up
+            Path(temp_file.name).unlink(missing_ok=True)
+    
+    def test_get_api_token(self, monkeypatch):
+        """Test getting API token from environment."""
+        # Set up environment variable
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "test_token_from_env")
+        
+        # Test getting token from environment
+        token = get_api_token()
+        assert token == "test_token_from_env"
+
+    def test_create_clickup_client(self, monkeypatch):
+        """Test creating ClickUp client with token."""
+        with patch("clickup_mcp.client.ClickUpAPIClient") as mock_client:
+            # Create client with explicit token
+            client = create_clickup_client(api_token="test_token")
+            
+            # Check that the client was created with the correct token
+            mock_client.assert_called_once_with(api_token="test_token")
+    
+    def test_get_api_token_missing(self, monkeypatch):
+        """Test error when API token is missing from environment."""
+        # Ensure environment is clean
+        monkeypatch.delenv("CLICKUP_API_TOKEN", raising=False)
+        
+        # Test that ValueError is raised when token is missing
+        with pytest.raises(ValueError, match="ClickUp API token not found"):
+            get_api_token()
+    
+    def test_entry_point_env_loading(self, monkeypatch):
+        """Test environment loading at entry point."""
+        from clickup_mcp.entry import run_server
+        from clickup_mcp.models.cli import ServerConfig
+        
+        # Create a temporary .env file
+        with tempfile.NamedTemporaryFile(suffix=".env", delete=False) as temp_file:
+            temp_file.write(b"CLICKUP_API_TOKEN=test_token_from_entry_point")
+        
+        try:
+            # Ensure environment is clean
+            monkeypatch.delenv("CLICKUP_API_TOKEN", raising=False)
+            
+            # Mock uvicorn.run to prevent actual server startup
+            with patch("uvicorn.run"), patch("clickup_mcp.web_server.app.create_app"):
+                # Create server config with our temp env file
+                config = ServerConfig(env_file=temp_file.name)
+                
+                # Run the server (should load environment from our file)
+                run_server(config)
+                
+                # Check that environment was loaded correctly
+                assert os.environ.get("CLICKUP_API_TOKEN") == "test_token_from_entry_point"
+        finally:
+            # Clean up
+            Path(temp_file.name).unlink(missing_ok=True)

--- a/uv.lock
+++ b/uv.lock
@@ -81,6 +81,7 @@ dependencies = [
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
+    { name = "python-dotenv" },
     { name = "uvicorn" },
 ]
 
@@ -102,6 +103,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.10.1" },
     { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
 


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Add one new command line option `--env` to set the specific file path to load environment variables

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID:
        * CU-86eu7h99v
            * [x] CU-86eu7npzg
            * [ ] CU-86eu7nq0w
            * [ ] CU-86eu7nq32
    * Relative task IDs: N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    Add a new command line option
    ```console
    >>> uv run clickup-mcp-server --help
    usage: clickup-mcp-server [-h] [--host HOST] [--port PORT] [--log-level {debug,info,warning,error,critical}] [--reload] [--env ENV_FILE]
    
    Run the ClickUp MCP FastAPI server
    
    options:
      -h, --help            show this help message and exit
      --host HOST           Host to bind the server to
      --port PORT           Port to bind the server to
      --log-level {debug,info,warning,error,critical}
                            Logging level
      --reload              Enable auto-reload for development
      --env ENV_FILE        Path to the .env file for environment variables
    ```


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Add new features with a little bit breaking changes.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Add a new dependency about features loads secret info from the *.env* file.
* Add a new initial step about loading *.env* file to set the secret info.
* Change the API token doesn't be given as a MCP server function parameter, the secret value would be got from environment variable.
* Add a new command line option to set the specific file path of the *.env* file for loading the secret info.
