### PR TITLE
[MCP-32] ✨ feat: Add workspace creation input model

### DIFF
--- a/clickup_mcp/mcp_server/models/inputs/workspace.py
+++ b/clickup_mcp/mcp_server/models/inputs/workspace.py
@@ -24,9 +24,7 @@ class WorkspaceCreateInput(BaseModel):
         WorkspaceCreateInput(name="Engineering Team", color="#3498db")
     """
 
-    model_config = ConfigDict(
-        json_schema_extra={"examples": [{"name": "Engineering Team", "color": "#3498db"}]}
-    )
+    model_config = ConfigDict(json_schema_extra={"examples": [{"name": "Engineering Team", "color": "#3498db"}]})
 
     name: str = Field(
         ...,

--- a/clickup_mcp/mcp_server/models/inputs/workspace.py
+++ b/clickup_mcp/mcp_server/models/inputs/workspace.py
@@ -1,0 +1,141 @@
+"""MCP input models for workspace operations.
+
+High-signal schemas for FastMCP: include constraints and examples to aid LLMs.
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class WorkspaceCreateInput(BaseModel):
+    """
+    Create a workspace. HTTP: POST /team
+
+    When to use: You want to create a new workspace with custom settings.
+    Notes: Workspaces are the top-level organization in ClickUp.
+
+    Attributes:
+        name: Workspace name
+        color: Workspace color for UI
+        avatar: Workspace avatar URL
+
+    Examples:
+        WorkspaceCreateInput(name="Engineering Team", color="#3498db")
+    """
+
+    model_config = {
+        "json_schema_extra": {"examples": [{"name": "Engineering Team", "color": "#3498db"}]}
+    }
+
+    name: str = Field(
+        ..., min_length=1, max_length=100, description="Workspace name.", examples=["Engineering Team", "Product", "Marketing"]
+    )
+    color: Optional[str] = Field(
+        None,
+        description="Workspace color in hex format.",
+        examples=["#3498db", "#e74c3c", "#2ecc71"],
+        pattern=r"^#[0-9A-Fa-f]{6}$",
+    )
+    avatar: Optional[str] = Field(
+        None,
+        description="Workspace avatar URL.",
+        examples=["https://example.com/avatar.png"],
+    )
+
+
+class WorkspaceGetInput(BaseModel):
+    """
+    Get a workspace. HTTP: GET /team/{team_id}
+
+    When to use: Retrieve details for a single workspace by ID.
+
+    Attributes:
+        workspace_id: Workspace ID
+
+    Examples:
+        WorkspaceGetInput(workspace_id="9018752317")
+    """
+
+    model_config = {"json_schema_extra": {"examples": [{"workspace_id": "9018752317"}]}}
+
+    workspace_id: str = Field(
+        ..., min_length=1, description="Workspace ID.", examples=["9018752317", "team_1"]
+    )
+
+
+class WorkspaceUpdateInput(BaseModel):
+    """
+    Update a workspace. HTTP: PUT /team/{team_id}
+
+    When to use: Change workspace attributes like name, color, or avatar.
+
+    Attributes:
+        workspace_id: Workspace ID
+        name: New workspace name
+        color: New workspace color
+        avatar: New workspace avatar URL
+
+    Examples:
+        WorkspaceUpdateInput(workspace_id="9018752317", name="Updated Team Name")
+    """
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {"workspace_id": "9018752317", "name": "Updated Team Name"},
+                {"workspace_id": "9018752317", "color": "#e74c3c"},
+            ]
+        }
+    }
+
+    workspace_id: str = Field(
+        ..., min_length=1, description="Workspace ID.", examples=["9018752317", "team_1"]
+    )
+    name: Optional[str] = Field(
+        None, min_length=1, max_length=100, description="Workspace name.", examples=["Engineering Team", "Product"]
+    )
+    color: Optional[str] = Field(
+        None,
+        description="Workspace color in hex format.",
+        examples=["#3498db", "#e74c3c", "#2ecc71"],
+        pattern=r"^#[0-9A-Fa-f]{6}$",
+    )
+    avatar: Optional[str] = Field(
+        None,
+        description="Workspace avatar URL.",
+        examples=["https://example.com/avatar.png"],
+    )
+
+
+class WorkspaceDeleteInput(BaseModel):
+    """
+    Delete a workspace. HTTP: DELETE /team/{team_id}
+
+    When to use: Permanently remove a workspace. Ensure no critical data is lost.
+
+    Attributes:
+        workspace_id: Workspace ID
+
+    Examples:
+        WorkspaceDeleteInput(workspace_id="9018752317")
+    """
+
+    model_config = {"json_schema_extra": {"examples": [{"workspace_id": "9018752317"}]}}
+
+    workspace_id: str = Field(
+        ..., min_length=1, description="Workspace ID.", examples=["9018752317", "team_1"]
+    )
+
+
+class WorkspaceListInput(BaseModel):
+    """
+    List workspaces. HTTP: GET /team
+
+    When to use: Discover all workspaces accessible to the user.
+
+    Examples:
+        WorkspaceListInput()
+    """
+
+    model_config = {"json_schema_extra": {"examples": [{}]}}

--- a/clickup_mcp/mcp_server/models/inputs/workspace.py
+++ b/clickup_mcp/mcp_server/models/inputs/workspace.py
@@ -5,7 +5,7 @@ High-signal schemas for FastMCP: include constraints and examples to aid LLMs.
 
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class WorkspaceCreateInput(BaseModel):
@@ -24,9 +24,9 @@ class WorkspaceCreateInput(BaseModel):
         WorkspaceCreateInput(name="Engineering Team", color="#3498db")
     """
 
-    model_config = {
-        "json_schema_extra": {"examples": [{"name": "Engineering Team", "color": "#3498db"}]}
-    }
+    model_config = ConfigDict(
+        json_schema_extra={"examples": [{"name": "Engineering Team", "color": "#3498db"}]}
+    )
 
     name: str = Field(
         ..., min_length=1, max_length=100, description="Workspace name.", examples=["Engineering Team", "Product", "Marketing"]
@@ -57,7 +57,7 @@ class WorkspaceGetInput(BaseModel):
         WorkspaceGetInput(workspace_id="9018752317")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"workspace_id": "9018752317"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"workspace_id": "9018752317"}]})
 
     workspace_id: str = Field(
         ..., min_length=1, description="Workspace ID.", examples=["9018752317", "team_1"]
@@ -80,14 +80,14 @@ class WorkspaceUpdateInput(BaseModel):
         WorkspaceUpdateInput(workspace_id="9018752317", name="Updated Team Name")
     """
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        json_schema_extra={
             "examples": [
                 {"workspace_id": "9018752317", "name": "Updated Team Name"},
                 {"workspace_id": "9018752317", "color": "#e74c3c"},
             ]
         }
-    }
+    )
 
     workspace_id: str = Field(
         ..., min_length=1, description="Workspace ID.", examples=["9018752317", "team_1"]
@@ -121,7 +121,7 @@ class WorkspaceDeleteInput(BaseModel):
         WorkspaceDeleteInput(workspace_id="9018752317")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"workspace_id": "9018752317"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"workspace_id": "9018752317"}]})
 
     workspace_id: str = Field(
         ..., min_length=1, description="Workspace ID.", examples=["9018752317", "team_1"]
@@ -138,4 +138,4 @@ class WorkspaceListInput(BaseModel):
         WorkspaceListInput()
     """
 
-    model_config = {"json_schema_extra": {"examples": [{}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{}]})

--- a/clickup_mcp/mcp_server/models/inputs/workspace.py
+++ b/clickup_mcp/mcp_server/models/inputs/workspace.py
@@ -24,12 +24,14 @@ class WorkspaceCreateInput(BaseModel):
         WorkspaceCreateInput(name="Engineering Team", color="#3498db")
     """
 
-    model_config = {
-        "json_schema_extra": {"examples": [{"name": "Engineering Team", "color": "#3498db"}]}
-    }
+    model_config = {"json_schema_extra": {"examples": [{"name": "Engineering Team", "color": "#3498db"}]}}
 
     name: str = Field(
-        ..., min_length=1, max_length=100, description="Workspace name.", examples=["Engineering Team", "Product", "Marketing"]
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Workspace name.",
+        examples=["Engineering Team", "Product", "Marketing"],
     )
     color: Optional[str] = Field(
         None,
@@ -59,9 +61,7 @@ class WorkspaceGetInput(BaseModel):
 
     model_config = {"json_schema_extra": {"examples": [{"workspace_id": "9018752317"}]}}
 
-    workspace_id: str = Field(
-        ..., min_length=1, description="Workspace ID.", examples=["9018752317", "team_1"]
-    )
+    workspace_id: str = Field(..., min_length=1, description="Workspace ID.", examples=["9018752317", "team_1"])
 
 
 class WorkspaceUpdateInput(BaseModel):
@@ -89,9 +89,7 @@ class WorkspaceUpdateInput(BaseModel):
         }
     }
 
-    workspace_id: str = Field(
-        ..., min_length=1, description="Workspace ID.", examples=["9018752317", "team_1"]
-    )
+    workspace_id: str = Field(..., min_length=1, description="Workspace ID.", examples=["9018752317", "team_1"])
     name: Optional[str] = Field(
         None, min_length=1, max_length=100, description="Workspace name.", examples=["Engineering Team", "Product"]
     )
@@ -123,9 +121,7 @@ class WorkspaceDeleteInput(BaseModel):
 
     model_config = {"json_schema_extra": {"examples": [{"workspace_id": "9018752317"}]}}
 
-    workspace_id: str = Field(
-        ..., min_length=1, description="Workspace ID.", examples=["9018752317", "team_1"]
-    )
+    workspace_id: str = Field(..., min_length=1, description="Workspace ID.", examples=["9018752317", "team_1"])
 
 
 class WorkspaceListInput(BaseModel):


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Add workspace creation input models with validation following the existing pattern for space models.

* ### Task tickets:

    * Task ID: MCP-32
    * Relative task IDs:
        * [ ] MCP-20 (Story: Workspace Creation and Management)
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    - Created new file: clickup_mcp/mcp_server/models/inputs/workspace.py
    - Added 5 input models: WorkspaceCreateInput, WorkspaceGetInput, WorkspaceUpdateInput, WorkspaceDeleteInput, WorkspaceListInput
    - Followed existing pattern from space.py for consistency
    - Added proper validation and examples for all models


## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (maybe performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] ✍️ Command line interface
    * [x] 💼 Core feature
        * [ ] 🕸️ Web server
        * [ ] 🤖 MCP server
        * [ ] 🪡 API client
        * [x] 🫀 Data model
    * [ ] 🎨 UI/UX (maybe command line interface, etc.)
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
        * [ ] 🧪 Contract testing
    * [ ] 📚 Documentation
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
* Additional description:
    N/A.


## _Description_

* Added workspace input models to support workspace management features in the MCP server. The models follow the existing pattern from space.py and include proper validation, constraints, and examples to aid LLMs in using the MCP tools effectively.