### PR TITLE
[MCP-39] ✨ feat: Add workspace creation MCP tool

### DIFF
--- a/clickup_mcp/mcp_server/models/outputs/workspace.py
+++ b/clickup_mcp/mcp_server/models/outputs/workspace.py
@@ -2,18 +2,21 @@
 Result models for Workspace (Team) tools.
 
 These are concise, high-signal shapes returned by MCP tools when listing
-workspaces (teams). Optimized for LLM consumption.
+workspaces (teams) or performing individual operations. Optimized for LLM consumption.
 
 Usage Examples:
     # Python - Single item
-    from clickup_mcp.mcp_server.models.outputs.workspace import WorkspaceListItem, WorkspaceListResult
+    from clickup_mcp.mcp_server.models.outputs.workspace import WorkspaceListItem, WorkspaceListResult, WorkspaceResult
     item = WorkspaceListItem(team_id="team_1", name="Engineering")
-
+    
     # Python - List result
     result = WorkspaceListResult(items=[item])
+    
+    # Python - Individual workspace result
+    workspace_result = WorkspaceResult(id="team_1", name="Engineering", color="#3498db")
 """
 
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -46,3 +49,41 @@ class WorkspaceListResult(BaseModel):
     )
 
     model_config = {"json_schema_extra": {"examples": [{"items": [{"team_id": "team_1", "name": "Engineering"}]}]}}
+
+
+class WorkspaceResult(BaseModel):
+    """
+    Result model for individual workspace operations (create, get, update).
+
+    Attributes:
+        id: Workspace ID
+        name: Workspace name
+        color: Workspace color in hex format
+        avatar: Workspace avatar URL
+    """
+
+    id: str = Field(..., description="Workspace ID", examples=["9018752317", "team_1"])
+    name: str = Field(..., description="Workspace name", examples=["Engineering", "Ops"])
+    color: Optional[str] = Field(
+        default=None,
+        description="Workspace color in hex format",
+        examples=["#3498db", "#e74c3c"],
+    )
+    avatar: Optional[str] = Field(
+        default=None,
+        description="Workspace avatar URL",
+        examples=["https://example.com/avatar.png"],
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "id": "9018752317",
+                    "name": "Engineering",
+                    "color": "#3498db",
+                    "avatar": "https://example.com/avatar.png",
+                }
+            ]
+        }
+    }

--- a/clickup_mcp/mcp_server/models/outputs/workspace.py
+++ b/clickup_mcp/mcp_server/models/outputs/workspace.py
@@ -8,10 +8,10 @@ Usage Examples:
     # Python - Single item
     from clickup_mcp.mcp_server.models.outputs.workspace import WorkspaceListItem, WorkspaceListResult, WorkspaceResult
     item = WorkspaceListItem(team_id="team_1", name="Engineering")
-    
+
     # Python - List result
     result = WorkspaceListResult(items=[item])
-    
+
     # Python - Individual workspace result
     workspace_result = WorkspaceResult(id="team_1", name="Engineering", color="#3498db")
 """

--- a/clickup_mcp/mcp_server/workspace.py
+++ b/clickup_mcp/mcp_server/workspace.py
@@ -1,14 +1,24 @@
 """MCP tools for ClickUp Workspaces (a.k.a Teams in v2).
 
-Tool: workspace.list -> List workspaces available to the token.
+This module exposes workspace tools following the scope.operation naming:
+- workspace.list, workspace.create, workspace.get, workspace.update, workspace.delete
 """
 
 from clickup_mcp.client import ClickUpAPIClientFactory
 from clickup_mcp.mcp_server.errors import handle_tool_errors
+from clickup_mcp.mcp_server.models.inputs.workspace import (
+    WorkspaceCreateInput,
+    WorkspaceDeleteInput,
+    WorkspaceGetInput,
+    WorkspaceUpdateInput,
+)
+from clickup_mcp.mcp_server.models.outputs.common import DeletionResult
 from clickup_mcp.mcp_server.models.outputs.workspace import (
     WorkspaceListResult,
+    WorkspaceResult,
 )
 from clickup_mcp.models.mapping.team_mapper import TeamMapper
+from clickup_mcp.models.mapping.workspace_mapper import WorkspaceMapper
 
 from .app import mcp
 
@@ -55,3 +65,207 @@ async def workspace_list() -> WorkspaceListResult:
     async with client:
         teams = await client.team.get_authorized_teams()
     return TeamMapper.to_workspace_list_result_output(teams)
+
+
+@mcp.tool(
+    name="workspace.create",
+    title="Create Workspace",
+    description=(
+        "Create a new workspace (team) with a name, optional color, and avatar. "
+        "HTTP: POST /team. Returns the created workspace details."
+    ),
+    annotations={
+        "readOnlyHint": False,
+        "openWorldHint": False,
+    },
+)
+@handle_tool_errors
+async def workspace_create(input: WorkspaceCreateInput) -> WorkspaceResult:
+    """
+    Create a new workspace (team).
+
+    API:
+        POST /team
+
+    Args:
+        input: WorkspaceCreateInput with name, optional color, and avatar
+
+    Returns:
+        WorkspaceResult: Created workspace details
+
+    Error Handling:
+        This function is wrapped by `@handle_tool_errors` and returns a ToolResponse at runtime.
+        On failure, `ok=False` with issues (e.g., VALIDATION_ERROR, RATE_LIMIT, INTERNAL).
+
+    Examples:
+        # Python (async)
+        response = await workspace_create(WorkspaceCreateInput(name="Engineering Team", color="#3498db"))
+        if response.ok:
+            print(response.result.id, response.result.name)
+    """
+    # Map MCP input to domain entity
+    workspace_domain = WorkspaceMapper.from_create_input(input)
+    # Convert domain to DTO for API request
+    workspace_create_dto = WorkspaceMapper.to_create_dto(workspace_domain)
+
+    # Call API
+    client = ClickUpAPIClientFactory.get()
+    async with client:
+        workspace_resp = await client.team.create_workspace(workspace_create_dto)
+
+    if workspace_resp is None:
+        raise Exception("Failed to create workspace")
+
+    # Convert API response to domain entity
+    workspace_domain = WorkspaceMapper.to_domain(workspace_resp)
+    # Convert domain to MCP output
+    return WorkspaceMapper.to_workspace_result_output(workspace_domain)
+
+
+@mcp.tool(
+    name="workspace.get",
+    title="Get Workspace",
+    description=(
+        "Get a workspace (team) by its ID. If you don't know the ID, call `workspace.list` first. "
+        "HTTP: GET /team/{team_id}."
+    ),
+    annotations={
+        "readOnlyHint": True,
+        "openWorldHint": True,
+    },
+)
+@handle_tool_errors
+async def workspace_get(input: WorkspaceGetInput) -> WorkspaceResult:
+    """
+    Get a workspace by ID.
+
+    API:
+        GET /team/{team_id}
+
+    Args:
+        input: WorkspaceGetInput with workspace_id
+
+    Returns:
+        WorkspaceResult: Workspace details
+
+    Error Handling:
+        This function is wrapped by `@handle_tool_errors` and returns a ToolResponse at runtime.
+        On failure, `ok=False` with issues (e.g., NOT_FOUND, PERMISSION_DENIED, RATE_LIMIT).
+
+    Examples:
+        # Python (async)
+        response = await workspace_get(WorkspaceGetInput(workspace_id="9018752317"))
+        if response.ok:
+            print(response.result.name)
+    """
+    # Call API
+    client = ClickUpAPIClientFactory.get()
+    async with client:
+        workspace_resp = await client.team.get_workspace(input.workspace_id)
+
+    if workspace_resp is None:
+        raise Exception(f"Failed to get workspace: {input.workspace_id}")
+
+    # Convert API response to domain entity
+    workspace_domain = WorkspaceMapper.to_domain(workspace_resp)
+    # Convert domain to MCP output
+    return WorkspaceMapper.to_workspace_result_output(workspace_domain)
+
+
+@mcp.tool(
+    name="workspace.update",
+    title="Update Workspace",
+    description=(
+        "Update an existing workspace's name, color, or avatar. "
+        "HTTP: PUT /team/{team_id}. Returns the updated workspace details."
+    ),
+    annotations={
+        "readOnlyHint": False,
+        "openWorldHint": False,
+    },
+)
+@handle_tool_errors
+async def workspace_update(input: WorkspaceUpdateInput) -> WorkspaceResult:
+    """
+    Update a workspace.
+
+    API:
+        PUT /team/{team_id}
+
+    Args:
+        input: WorkspaceUpdateInput with workspace_id and optional fields to update
+
+    Returns:
+        WorkspaceResult: Updated workspace details
+
+    Error Handling:
+        This function is wrapped by `@handle_tool_errors` and returns a ToolResponse at runtime.
+        On failure, `ok=False` with issues (e.g., NOT_FOUND, PERMISSION_DENIED, RATE_LIMIT).
+
+    Examples:
+        # Python (async)
+        response = await workspace_update(WorkspaceUpdateInput(workspace_id="9018752317", name="Updated Name"))
+        if response.ok:
+            print(response.result.name)
+    """
+    # Map MCP input to domain entity
+    workspace_domain = WorkspaceMapper.from_update_input(input)
+    # Convert domain to DTO for API request
+    workspace_update_dto = WorkspaceMapper.to_update_dto(workspace_domain)
+
+    # Call API
+    client = ClickUpAPIClientFactory.get()
+    async with client:
+        workspace_resp = await client.team.update_workspace(input.workspace_id, workspace_update_dto)
+
+    if workspace_resp is None:
+        raise Exception(f"Failed to update workspace: {input.workspace_id}")
+
+    # Convert API response to domain entity
+    workspace_domain = WorkspaceMapper.to_domain(workspace_resp)
+    # Convert domain to MCP output
+    return WorkspaceMapper.to_workspace_result_output(workspace_domain)
+
+
+@mcp.tool(
+    name="workspace.delete",
+    title="Delete Workspace",
+    description=(
+        "Delete a workspace (team) by its ID. This action cannot be undone. "
+        "HTTP: DELETE /team/{team_id}. Returns success/failure status."
+    ),
+    annotations={
+        "readOnlyHint": False,
+        "openWorldHint": False,
+    },
+)
+@handle_tool_errors
+async def workspace_delete(input: WorkspaceDeleteInput) -> DeletionResult:
+    """
+    Delete a workspace.
+
+    API:
+        DELETE /team/{team_id}
+
+    Args:
+        input: WorkspaceDeleteInput with workspace_id
+
+    Returns:
+        DeletionResult: Success status and message
+
+    Error Handling:
+        This function is wrapped by `@handle_tool_errors` and returns a ToolResponse at runtime.
+        On failure, `ok=False` with issues (e.g., NOT_FOUND, PERMISSION_DENIED, RATE_LIMIT).
+
+    Examples:
+        # Python (async)
+        response = await workspace_delete(WorkspaceDeleteInput(workspace_id="9018752317"))
+        if response.ok:
+            print(response.result.ok)
+    """
+    # Call API
+    client = ClickUpAPIClientFactory.get()
+    async with client:
+        success = await client.team.delete_workspace(input.workspace_id)
+
+    return DeletionResult(ok=success)


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Implement workspace MCP tools for create, get, update, and delete operations following the existing space tool pattern.

* ### Task tickets:

    * Task ID: MCP-39
    * Relative task IDs:
        * [ ] MCP-20 (Story: Workspace Creation and Management)
    * Relative PRs:
        * [ ] #275 (PR 1.1: Workspace Input Models)
        * [ ] #276 (PR 1.2: Workspace Domain Models)
        * [ ] #277 (PR 1.3: Workspace DTOs and Mappers)

* ### Key point change (optional):

    - Added workspace MCP tools: workspace.create, workspace.get, workspace.update, workspace.delete
    - Added WorkspaceResult output model for individual workspace operations
    - Extended existing workspace.py file with CRUD operations
    - Followed existing space tool pattern for consistency
    - Used @handle_tool_errors decorator for error handling
    - Integrated with WorkspaceMapper for DTO ↔ Domain translation


## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (maybe performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] ✍️ Command line interface
    * [x] 💼 Core feature
        * [ ] 🕸️ Web server
        * [x] 🤖 MCP server
        * [ ] 🪡 API client
        * [ ] 🫀 Data model
    * [ ] 🎨 UI/UX (maybe command line interface, etc.)
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
        * [ ] 🧪 Contract testing
    * [ ] 📚 Documentation
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
* Additional description:
    N/A.


## _Description_

* Added workspace MCP tools for full CRUD operations (create, get, update, delete) following the existing space tool pattern. The tools use the WorkspaceMapper for DTO ↔ Domain translation and are decorated with @handle_tool_errors for consistent error handling. Also added the WorkspaceResult output model for individual workspace operations.