### PR TITLE
[MCP-45] ✨ task: Add assignment models and domain logic

### DIFF
--- a/clickup_mcp/mcp_server/models/inputs/folder.py
+++ b/clickup_mcp/mcp_server/models/inputs/folder.py
@@ -5,7 +5,7 @@ High-signal schemas with constraints and examples for FastMCP.
 
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class FolderCreateInput(BaseModel):
@@ -23,7 +23,7 @@ class FolderCreateInput(BaseModel):
         FolderCreateInput(space_id="space_1", name="[TEST] Planning")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"space_id": "space_1", "name": "[TEST] Planning"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"space_id": "space_1", "name": "[TEST] Planning"}]})
 
     space_id: str = Field(..., min_length=1, description="Parent space ID.", examples=["space_1", "spc_abc"])
     name: str = Field(..., min_length=1, description="Folder name.", examples=["[TEST] Planning", "Roadmap"])
@@ -42,7 +42,7 @@ class FolderGetInput(BaseModel):
         FolderGetInput(folder_id="folder_1")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"folder_id": "folder_1"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"folder_id": "folder_1"}]})
 
     folder_id: str = Field(..., min_length=1, description="Folder ID.", examples=["folder_1", "fld_abc"])
 
@@ -61,7 +61,7 @@ class FolderUpdateInput(BaseModel):
         FolderUpdateInput(folder_id="folder_1", name="Roadmap")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"folder_id": "folder_1", "name": "Roadmap"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"folder_id": "folder_1", "name": "Roadmap"}]})
 
     folder_id: str = Field(..., min_length=1, description="Folder ID.", examples=["folder_1", "fld_abc"])
     name: Optional[str] = Field(None, min_length=1, description="New folder name.", examples=["Roadmap", "Planning"])
@@ -80,7 +80,7 @@ class FolderDeleteInput(BaseModel):
         FolderDeleteInput(folder_id="folder_1")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"folder_id": "folder_1"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"folder_id": "folder_1"}]})
 
     folder_id: str = Field(
         ..., min_length=1, description="Folder ID.", json_schema_extra={"examples": ["folder_1", "fld_abc"]}
@@ -100,6 +100,6 @@ class FolderListInSpaceInput(BaseModel):
         FolderListInSpaceInput(space_id="space_1")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"space_id": "space_1"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"space_id": "space_1"}]})
 
     space_id: str = Field(..., min_length=1, description="Space ID.", examples=["space_1", "spc_abc"])

--- a/clickup_mcp/mcp_server/models/inputs/list_.py
+++ b/clickup_mcp/mcp_server/models/inputs/list_.py
@@ -5,7 +5,7 @@ High-signal schemas for FastMCP with constraints and examples.
 
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ListCreateInput(BaseModel):
@@ -37,11 +37,11 @@ class ListCreateInput(BaseModel):
         ListCreateInput(folder_id="folder_1", name="Bugs", priority=2, due_date=1731523200000)
     """
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        json_schema_extra={
             "examples": [{"folder_id": "folder_1", "name": "Sprint Backlog", "status": "Open", "priority": 2}]
         }
-    }
+    )
 
     folder_id: str = Field(..., min_length=1, description="Parent folder ID.", examples=["folder_1", "fld_abc"])
     name: str = Field(..., min_length=1, description="List name.", examples=["Sprint Backlog", "Bugs"])
@@ -68,7 +68,7 @@ class ListGetInput(BaseModel):
         ListGetInput(list_id="list_1")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"list_id": "list_1"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"list_id": "list_1"}]})
 
     list_id: str = Field(..., min_length=1, description="List ID.", examples=["list_1", "lst_abc"])
 
@@ -93,11 +93,11 @@ class ListUpdateInput(BaseModel):
         ListUpdateInput(list_id="list_1", name="Sprint 12", status="In progress", priority=3)
     """
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        json_schema_extra={
             "examples": [{"list_id": "list_1", "name": "Sprint 12", "status": "In progress", "priority": 3}]
         }
-    }
+    )
 
     list_id: str = Field(..., min_length=1, description="List ID.", examples=["list_1", "lst_abc"])
     name: Optional[str] = Field(None, min_length=1, description="List name.", examples=["Sprint 12", "Bugs"])
@@ -124,7 +124,7 @@ class ListDeleteInput(BaseModel):
         ListDeleteInput(list_id="list_1")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"list_id": "list_1"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"list_id": "list_1"}]})
 
     list_id: str = Field(
         ..., min_length=1, description="List ID.", json_schema_extra={"examples": ["list_1", "lst_abc"]}
@@ -144,7 +144,7 @@ class ListListInFolderInput(BaseModel):
         ListListInFolderInput(folder_id="folder_1")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"folder_id": "folder_1"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"folder_id": "folder_1"}]})
 
     folder_id: str = Field(..., min_length=1, description="Folder ID.", examples=["folder_1", "fld_abc"])
 
@@ -162,7 +162,7 @@ class ListListInSpaceFolderlessInput(BaseModel):
         ListListInSpaceFolderlessInput(space_id="space_1")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"space_id": "space_1"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"space_id": "space_1"}]})
 
     space_id: str = Field(..., min_length=1, description="Space ID.", examples=["space_1", "spc_abc"])
 
@@ -181,7 +181,7 @@ class ListAddTaskInput(BaseModel):
         ListAddTaskInput(list_id="list_2", task_id="task_123")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"list_id": "list_2", "task_id": "task_123"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"list_id": "list_2", "task_id": "task_123"}]})
 
     list_id: str = Field(..., min_length=1, description="Target list ID.", examples=["list_2", "lst_abc"])
     task_id: str = Field(..., min_length=1, description="Existing task ID.", examples=["task_123", "tsk_abc"])
@@ -201,7 +201,7 @@ class ListRemoveTaskInput(BaseModel):
         ListRemoveTaskInput(list_id="list_2", task_id="task_123")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"list_id": "list_2", "task_id": "task_123"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"list_id": "list_2", "task_id": "task_123"}]})
 
     list_id: str = Field(
         ..., min_length=1, description="Target list ID.", json_schema_extra={"examples": ["list_2", "lst_abc"]}

--- a/clickup_mcp/mcp_server/models/inputs/space.py
+++ b/clickup_mcp/mcp_server/models/inputs/space.py
@@ -5,7 +5,7 @@ High-signal schemas for FastMCP: include constraints and examples to aid LLMs.
 
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class SpaceCreateInput(BaseModel):
@@ -24,9 +24,9 @@ class SpaceCreateInput(BaseModel):
         SpaceCreateInput(team_id="team_1", name="[TEST] Eng", multiple_assignees=True)
     """
 
-    model_config = {
-        "json_schema_extra": {"examples": [{"team_id": "team_1", "name": "[TEST] Eng", "multiple_assignees": True}]}
-    }
+    model_config = ConfigDict(
+        json_schema_extra={"examples": [{"team_id": "team_1", "name": "[TEST] Eng", "multiple_assignees": True}]}
+    )
 
     team_id: str = Field(
         ..., min_length=1, description="Target workspace (team) ID.", examples=["9018752317", "team_1"]
@@ -52,7 +52,7 @@ class SpaceGetInput(BaseModel):
         SpaceGetInput(space_id="space_1")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"space_id": "space_1"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"space_id": "space_1"}]})
 
     space_id: str = Field(..., min_length=1, description="Space ID.", examples=["space_1", "abc123"])
 
@@ -73,14 +73,14 @@ class SpaceUpdateInput(BaseModel):
         SpaceUpdateInput(space_id="space_1", name="Delivery", private=False)
     """
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        json_schema_extra={
             "examples": [
                 {"space_id": "space_1", "name": "Delivery", "private": False},
                 {"space_id": "space_1", "multiple_assignees": True},
             ]
         }
-    }
+    )
 
     space_id: str = Field(..., min_length=1, description="Space ID.", examples=["space_1", "abc123"])
     name: Optional[str] = Field(None, min_length=1, description="Space name.", examples=["Delivery", "Engineering"])
@@ -103,7 +103,7 @@ class SpaceDeleteInput(BaseModel):
         SpaceDeleteInput(space_id="space_1")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"space_id": "space_1"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"space_id": "space_1"}]})
 
     space_id: str = Field(..., min_length=1, description="Space ID.", examples=["space_1", "abc123"])
 
@@ -121,6 +121,6 @@ class SpaceListInput(BaseModel):
         SpaceListInput(team_id="team_1")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"team_id": "team_1"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"team_id": "team_1"}]})
 
     team_id: str = Field(..., min_length=1, description="Workspace (team) ID.", examples=["9018752317", "team_1"])

--- a/clickup_mcp/mcp_server/models/inputs/task.py
+++ b/clickup_mcp/mcp_server/models/inputs/task.py
@@ -313,3 +313,55 @@ class TaskAddDependencyInput(BaseModel):
         description="Dependency type (waiting_on/blocking).",
         examples=["waiting_on", "blocking"],
     )
+
+
+class TaskAddAssigneeInput(BaseModel):
+    """
+    Add an assignee to a task. HTTP: POST /task/{task_id}/member/{member_id}
+
+    When to use: Assign a user to a task. This adds the user to the task's assignees list.
+
+    Attributes:
+        task_id: Task ID to assign user to
+        assignee_id: User ID to assign to the task
+
+    Examples:
+        TaskAddAssigneeInput(task_id="task_123", assignee_id=42)
+    """
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{"task_id": "task_123", "assignee_id": 42}, {"task_id": "task_123", "assignee_id": "usr_abc"}]
+        }
+    }
+
+    task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "CU-123"])
+    assignee_id: int | str = Field(
+        ..., description="User ID to assign to the task.", examples=[42, "usr_abc"]
+    )
+
+
+class TaskRemoveAssigneeInput(BaseModel):
+    """
+    Remove an assignee from a task. HTTP: DELETE /task/{task_id}/member/{member_id}
+
+    When to use: Unassign a user from a task. This removes the user from the task's assignees list.
+
+    Attributes:
+        task_id: Task ID to remove user from
+        assignee_id: User ID to remove from the task
+
+    Examples:
+        TaskRemoveAssigneeInput(task_id="task_123", assignee_id=42)
+    """
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{"task_id": "task_123", "assignee_id": 42}, {"task_id": "task_123", "assignee_id": "usr_abc"}]
+        }
+    }
+
+    task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "CU-123"])
+    assignee_id: int | str = Field(
+        ..., description="User ID to remove from the task.", examples=[42, "usr_abc"]
+    )

--- a/clickup_mcp/mcp_server/models/inputs/task.py
+++ b/clickup_mcp/mcp_server/models/inputs/task.py
@@ -6,7 +6,7 @@ Domain entities first, then DTOs for ClickUp wire format.
 
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class TaskCreateInput(BaseModel):
@@ -41,8 +41,8 @@ class TaskCreateInput(BaseModel):
         TaskCreateInput(list_id="123", name="Implement child", parent="task_abc")
     """
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        json_schema_extra={
             "examples": [
                 {
                     "list_id": "123",
@@ -59,7 +59,7 @@ class TaskCreateInput(BaseModel):
                 },
             ]
         }
-    }
+    )
 
     list_id: str = Field(
         ...,
@@ -114,8 +114,8 @@ class TaskUpdateInput(BaseModel):
         TaskUpdateInput(task_id="task_123", status="done", priority=2, assignees=[42, 43])
     """
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        json_schema_extra={
             "examples": [
                 {
                     "task_id": "task_123",
@@ -125,7 +125,7 @@ class TaskUpdateInput(BaseModel):
                 }
             ]
         }
-    }
+    )
 
     task_id: str = Field(..., min_length=1, description="Target task ID.", examples=["task_123", "CU-123"])
     name: Optional[str] = Field(
@@ -165,14 +165,14 @@ class TaskGetInput(BaseModel):
         TaskGetInput(task_id="CU-123", custom_task_ids=True, team_id="team_1")
     """
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        json_schema_extra={
             "examples": [
                 {"task_id": "task_123"},
                 {"task_id": "CU-123", "custom_task_ids": True, "team_id": "team_1"},
             ]
         }
-    }
+    )
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "CU-123"])
     subtasks: Optional[bool] = Field(None, description="Include subtasks (true/false).", examples=[True, False])
@@ -207,14 +207,14 @@ class TaskListInListInput(BaseModel):
         TaskListInListInput(list_id="123", limit=50, statuses=["open", "in progress"])
     """
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        json_schema_extra={
             "examples": [
                 {"list_id": "123", "limit": 50, "statuses": ["open", "in progress"]},
                 {"list_id": "123", "page": 1, "limit": 100, "include_timl": True},
             ]
         }
-    }
+    )
 
     list_id: str = Field(..., min_length=1, description="List ID.", examples=["123", "list_1"])
     page: int = Field(0, ge=0, description="Page number (0-indexed).", examples=[0, 1, 2])
@@ -245,14 +245,14 @@ class TaskSetCustomFieldInput(BaseModel):
         TaskSetCustomFieldInput(task_id="task_123", field_id="cf_text", value="Ready to ship")
     """
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        json_schema_extra={
             "examples": [
                 {"task_id": "task_123", "field_id": "cf_priority", "value": 3},
                 {"task_id": "task_123", "field_id": "cf_text", "value": "Ready to ship"},
             ]
         }
-    }
+    )
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "CU-123"])
     field_id: str = Field(..., min_length=1, description="Custom field ID.", examples=["cf_priority", "cf_text"])
@@ -277,7 +277,7 @@ class TaskClearCustomFieldInput(BaseModel):
         TaskClearCustomFieldInput(task_id="task_123", field_id="cf_priority")
     """
 
-    model_config = {"json_schema_extra": {"examples": [{"task_id": "task_123", "field_id": "cf_priority"}]}}
+    model_config = ConfigDict(json_schema_extra={"examples": [{"task_id": "task_123", "field_id": "cf_priority"}]})
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "CU-123"])
     field_id: str = Field(..., min_length=1, description="Custom field ID.", examples=["cf_priority", "cf_text"])
@@ -298,11 +298,11 @@ class TaskAddDependencyInput(BaseModel):
         TaskAddDependencyInput(task_id="task_123", depends_on="task_456", dependency_type="waiting_on")
     """
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        json_schema_extra={
             "examples": [{"task_id": "task_123", "depends_on": "task_456", "dependency_type": "waiting_on"}]
         }
-    }
+    )
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123"])
     depends_on: str = Field(
@@ -329,11 +329,11 @@ class TaskAddAssigneeInput(BaseModel):
         TaskAddAssigneeInput(task_id="task_123", assignee_id=42)
     """
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        json_schema_extra={
             "examples": [{"task_id": "task_123", "assignee_id": 42}, {"task_id": "task_123", "assignee_id": "usr_abc"}]
         }
-    }
+    )
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "CU-123"])
     assignee_id: int | str = Field(
@@ -355,11 +355,11 @@ class TaskRemoveAssigneeInput(BaseModel):
         TaskRemoveAssigneeInput(task_id="task_123", assignee_id=42)
     """
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        json_schema_extra={
             "examples": [{"task_id": "task_123", "assignee_id": 42}, {"task_id": "task_123", "assignee_id": "usr_abc"}]
         }
-    }
+    )
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "CU-123"])
     assignee_id: int | str = Field(

--- a/clickup_mcp/mcp_server/models/inputs/task.py
+++ b/clickup_mcp/mcp_server/models/inputs/task.py
@@ -336,9 +336,7 @@ class TaskAddAssigneeInput(BaseModel):
     }
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "CU-123"])
-    assignee_id: int | str = Field(
-        ..., description="User ID to assign to the task.", examples=[42, "usr_abc"]
-    )
+    assignee_id: int | str = Field(..., description="User ID to assign to the task.", examples=[42, "usr_abc"])
 
 
 class TaskRemoveAssigneeInput(BaseModel):
@@ -362,6 +360,4 @@ class TaskRemoveAssigneeInput(BaseModel):
     }
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "CU-123"])
-    assignee_id: int | str = Field(
-        ..., description="User ID to remove from the task.", examples=[42, "usr_abc"]
-    )
+    assignee_id: int | str = Field(..., description="User ID to remove from the task.", examples=[42, "usr_abc"])

--- a/clickup_mcp/models/domain/task.py
+++ b/clickup_mcp/models/domain/task.py
@@ -350,6 +350,56 @@ class ClickUpTask(BaseDomainModel):
         # Replace existing assignees with provided
         self.assignee_ids = list(user_ids)
 
+    def add_assignee(self, user_id: int | str) -> None:
+        """
+        Add a single assignee to the task.
+
+        Adds the user ID to the assignees list if not already assigned.
+        Does not remove existing assignees.
+
+        Args:
+            user_id: User ID to add to the task
+
+        Usage Examples:
+            # Python - Add a single assignee
+            task = ClickUpTask(id="task_123", name="My Task")
+            task.add_assignee("user_789")
+            print(task.assignee_ids)  # ["user_789"]
+
+            # Python - Add another assignee (preserves existing)
+            task.add_assignee("user_790")
+            print(task.assignee_ids)  # ["user_789", "user_790"]
+
+            # Python - Adding duplicate user has no effect
+            task.add_assignee("user_789")
+            print(task.assignee_ids)  # ["user_789", "user_790"] (no duplicate)
+        """
+        if user_id not in self.assignee_ids:
+            self.assignee_ids.append(user_id)
+
+    def remove_assignee(self, user_id: int | str) -> None:
+        """
+        Remove a single assignee from the task.
+
+        Removes the user ID from the assignees list if present.
+        Does not affect other assignees.
+
+        Args:
+            user_id: User ID to remove from the task
+
+        Usage Examples:
+            # Python - Remove a single assignee
+            task = ClickUpTask(id="task_123", name="My Task", assignee_ids=["user_789", "user_790"])
+            task.remove_assignee("user_789")
+            print(task.assignee_ids)  # ["user_790"]
+
+            # Python - Removing non-existent user has no effect
+            task.remove_assignee("user_999")
+            print(task.assignee_ids)  # ["user_790"] (unchanged)
+        """
+        if user_id in self.assignee_ids:
+            self.assignee_ids.remove(user_id)
+
 
 # Backwards compatibility alias
 Task = ClickUpTask

--- a/clickup_mcp/models/dto/task.py
+++ b/clickup_mcp/models/dto/task.py
@@ -333,3 +333,25 @@ class TaskResp(BaseResponseDTO):
     custom_fields: List[CustomFieldValueResp] = Field(default_factory=builtins.list, description="Custom field values")
     dependencies: List[TaskDependency] | None = Field(default=None, description="Task dependencies")
     subtasks: List[SubtaskSummary] | None = Field(default=None, description="Subtasks")
+
+
+class AssignmentResponse(BaseResponseDTO):
+    """
+    DTO for assignment operation responses.
+
+    API:
+        POST /task/{task_id}/member/{member_id}
+        DELETE /task/{task_id}/member/{member_id}
+
+    Notes:
+        ClickUp returns a simple success/failure response for assignment operations.
+
+    Attributes:
+        success: Whether the assignment operation succeeded
+
+    Examples:
+        # Python - Successful assignment
+        AssignmentResponse(success=True)
+    """
+
+    success: bool = Field(description="Whether the assignment operation succeeded")


### PR DESCRIPTION
## Description
Add task assignment input models and domain logic

## Changes
- Added TaskAddAssigneeInput and TaskRemoveAssigneeInput MCP input models
- Extended ClickUpTask domain model with add_assignee() and remove_assignee() methods
- Added AssignmentResponse DTO for assignment operation responses

## Related Tasks
- Task 2.1: Design task assignment input models
- Task 2.2: Extend task domain with assignment logic
- Task 2.3: Create assignment DTOs and mapper extensions