### PR TITLE
[MCP-49] ✨ task: Add assignment API and MCP tool

### DIFF
--- a/clickup_mcp/api/task.py
+++ b/clickup_mcp/api/task.py
@@ -449,3 +449,63 @@ class TaskAPI:
         """
         response = await self._client.delete(f"/task/{task_id}")
         return response.success and response.status_code in (200, 204)
+
+    async def add_assignee(self, task_id: ClickUpTaskID, assignee_id: int | str) -> bool:
+        """
+        Add an assignee to a task.
+
+        API:
+            POST /task/{task_id}/member/{member_id}
+
+        Args:
+            task_id: The ID of the task
+            assignee_id: The ID of the user to assign to the task
+
+        Returns:
+            bool: True if assignee was successfully added, otherwise False
+
+        Examples:
+            # Python (async)
+            ok = await task_api.add_assignee("abc123", assignee_id=42)
+
+            # curl
+            curl -X POST -H "Authorization: pk_..." \
+              https://api.clickup.com/api/v2/task/abc123/member/42
+
+            # wget
+            wget --method=POST \
+              --header="Authorization: pk_..." \
+              https://api.clickup.com/api/v2/task/abc123/member/42
+        """
+        response = await self._client.post(f"/task/{task_id}/member/{assignee_id}")
+        return response.success and response.status_code in (200, 201)
+
+    async def remove_assignee(self, task_id: ClickUpTaskID, assignee_id: int | str) -> bool:
+        """
+        Remove an assignee from a task.
+
+        API:
+            DELETE /task/{task_id}/member/{member_id}
+
+        Args:
+            task_id: The ID of the task
+            assignee_id: The ID of the user to remove from the task
+
+        Returns:
+            bool: True if assignee was successfully removed, otherwise False
+
+        Examples:
+            # Python (async)
+            ok = await task_api.remove_assignee("abc123", assignee_id=42)
+
+            # curl
+            curl -X DELETE -H "Authorization: pk_..." \
+              https://api.clickup.com/api/v2/task/abc123/member/42
+
+            # wget
+            wget --method=DELETE \
+              --header="Authorization: pk_..." \
+              https://api.clickup.com/api/v2/task/abc123/member/42
+        """
+        response = await self._client.delete(f"/task/{task_id}/member/{assignee_id}")
+        return response.success and response.status_code in (200, 204)

--- a/clickup_mcp/mcp_server/models/inputs/task.py
+++ b/clickup_mcp/mcp_server/models/inputs/task.py
@@ -336,9 +336,7 @@ class TaskAddAssigneeInput(BaseModel):
     }
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "CU-123"])
-    assignee_id: int | str = Field(
-        ..., description="User ID to assign to the task.", examples=[42, "usr_abc"]
-    )
+    assignee_id: int | str = Field(..., description="User ID to assign to the task.", examples=[42, "usr_abc"])
 
 
 class TaskRemoveAssigneeInput(BaseModel):
@@ -362,6 +360,4 @@ class TaskRemoveAssigneeInput(BaseModel):
     }
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "CU-123"])
-    assignee_id: int | str = Field(
-        ..., description="User ID to remove from the task.", examples=[42, "usr_abc"]
-    )
+    assignee_id: int | str = Field(..., description="User ID to remove from the task.", examples=[42, "usr_abc"])

--- a/clickup_mcp/mcp_server/task.py
+++ b/clickup_mcp/mcp_server/task.py
@@ -5,17 +5,20 @@ Tools:
 - task.list_in_list
 - task.set_custom_field / task.clear_custom_field
 - task.add_dependency
+- task.add_assignee / task.remove_assignee
 """
 
 from clickup_mcp.client import ClickUpAPIClientFactory
 from clickup_mcp.exceptions import ClickUpAPIError, ResourceNotFoundError
 from clickup_mcp.mcp_server.errors import handle_tool_errors
 from clickup_mcp.mcp_server.models.inputs.task import (
+    TaskAddAssigneeInput,
     TaskAddDependencyInput,
     TaskClearCustomFieldInput,
     TaskCreateInput,
     TaskGetInput,
     TaskListInListInput,
+    TaskRemoveAssigneeInput,
     TaskSetCustomFieldInput,
     TaskUpdateInput,
 )
@@ -406,3 +409,85 @@ def _taskresp_to_result(resp: TaskResp) -> TaskResult:
 def _taskresp_to_list_item(resp: TaskResp) -> TaskListItem:
     dom = TaskMapper.to_domain(resp)
     return TaskMapper.to_task_list_item_output(dom, url=resp.url)
+
+
+@mcp.tool(
+    title="Add Assignee",
+    name="task.add_assignee",
+    description=(
+        "Add an assignee to a task. This adds the user to the task's assignees list. "
+        "HTTP: POST /task/{task_id}/member/{member_id}."
+    ),
+    annotations={
+        "destructiveHint": False,
+        "openWorldHint": True,
+    },
+)
+@handle_tool_errors
+async def task_add_assignee(input: TaskAddAssigneeInput) -> OperationResult:
+    """
+    Add an assignee to a task.
+
+    API:
+        POST /task/{task_id}/member/{member_id}
+
+    Args:
+        input: TaskAddAssigneeInput with task_id and assignee_id
+
+    Returns:
+        OperationResult: Success status
+
+    Error Handling:
+        This function is wrapped by `@handle_tool_errors` and returns a ToolResponse at runtime.
+        On failure, `ok=False` with issues (e.g., NOT_FOUND, PERMISSION_DENIED, RATE_LIMIT).
+
+    Examples:
+        # Python (async)
+        response = await task_add_assignee(TaskAddAssigneeInput(task_id="task_123", assignee_id=42))
+        if response.ok:
+            print(response.result.ok)
+    """
+    client = ClickUpAPIClientFactory.get()
+    success = await client.task.add_assignee(input.task_id, input.assignee_id)
+    return OperationResult(ok=success)
+
+
+@mcp.tool(
+    title="Remove Assignee",
+    name="task.remove_assignee",
+    description=(
+        "Remove an assignee from a task. This removes the user from the task's assignees list. "
+        "HTTP: DELETE /task/{task_id}/member/{member_id}."
+    ),
+    annotations={
+        "destructiveHint": False,
+        "openWorldHint": True,
+    },
+)
+@handle_tool_errors
+async def task_remove_assignee(input: TaskRemoveAssigneeInput) -> OperationResult:
+    """
+    Remove an assignee from a task.
+
+    API:
+        DELETE /task/{task_id}/member/{member_id}
+
+    Args:
+        input: TaskRemoveAssigneeInput with task_id and assignee_id
+
+    Returns:
+        OperationResult: Success status
+
+    Error Handling:
+        This function is wrapped by `@handle_tool_errors` and returns a ToolResponse at runtime.
+        On failure, `ok=False` with issues (e.g., NOT_FOUND, PERMISSION_DENIED, RATE_LIMIT).
+
+    Examples:
+        # Python (async)
+        response = await task_remove_assignee(TaskRemoveAssigneeInput(task_id="task_123", assignee_id=42))
+        if response.ok:
+            print(response.result.ok)
+    """
+    client = ClickUpAPIClientFactory.get()
+    success = await client.task.remove_assignee(input.task_id, input.assignee_id)
+    return OperationResult(ok=success)


### PR DESCRIPTION
## Description
Implement task assignment API and MCP tool

## Changes
- Added add_assignee() and remove_assignee() methods to TaskAPI
- Added task.add_assignee and task.remove_assignee MCP tools
- Updated imports and documentation

## Related Tasks
- Task 2.4: Implement task assignment API methods
- Task 2.5: Create task assignment MCP tool