### PR TITLE
[MCP-55] ✨ task: Add search API and MCP tool

### DIFF
--- a/clickup_mcp/api/task.py
+++ b/clickup_mcp/api/task.py
@@ -509,3 +509,36 @@ class TaskAPI:
         """
         response = await self._client.delete(f"/task/{task_id}/member/{assignee_id}")
         return response.success and response.status_code in (200, 204)
+
+    async def search(self, query: dict[str, Any]) -> Optional[TaskResp]:
+        """
+        Search tasks with natural language query and filters.
+
+        API:
+            GET /team/{team_id}/task with query parameters
+
+        Args:
+            query: Search query parameters including text query and filters
+
+        Returns:
+            Optional[TaskResp]: Task response with search results, or None if search failed
+
+        Examples:
+            # Python (async)
+            results = await task_api.search({"query": "urgent bugs", "priorities": [1, 2]})
+
+            # curl
+            curl -H "Authorization: pk_..." \
+              "https://api.clickup.com/api/v2/team/123/task?query=urgent%20bugs&priorities[]=1&priorities[]=2"
+
+            # wget
+            wget --header="Authorization: pk_..." \
+              "https://api.clickup.com/api/v2/team/123/task?query=urgent%20bugs&priorities[]=1&priorities[]=2"
+        """
+        team_id = query.get("team_id")
+        if not team_id:
+            raise ValueError("team_id is required for search")
+        response = await self._client.get(f"/team/{team_id}/task", params=query)
+        if response.success and response.data:
+            return TaskResp(**response.data)
+        return None

--- a/clickup_mcp/mcp_server/models/inputs/task.py
+++ b/clickup_mcp/mcp_server/models/inputs/task.py
@@ -336,9 +336,7 @@ class TaskAddAssigneeInput(BaseModel):
     }
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "CU-123"])
-    assignee_id: int | str = Field(
-        ..., description="User ID to assign to the task.", examples=[42, "usr_abc"]
-    )
+    assignee_id: int | str = Field(..., description="User ID to assign to the task.", examples=[42, "usr_abc"])
 
 
 class TaskRemoveAssigneeInput(BaseModel):
@@ -362,9 +360,7 @@ class TaskRemoveAssigneeInput(BaseModel):
     }
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "CU-123"])
-    assignee_id: int | str = Field(
-        ..., description="User ID to remove from the task.", examples=[42, "usr_abc"]
-    )
+    assignee_id: int | str = Field(..., description="User ID to remove from the task.", examples=[42, "usr_abc"])
 
 
 class TaskSearchInput(BaseModel):
@@ -415,10 +411,10 @@ class TaskSearchInput(BaseModel):
         }
     }
 
-    query: str = Field(..., min_length=1, description="Natural language search query.", examples=["urgent bugs", "API documentation"])
-    team_id: Optional[str] = Field(
-        None, description="Filter by team/workspace ID.", examples=["team_1", "9018752317"]
+    query: str = Field(
+        ..., min_length=1, description="Natural language search query.", examples=["urgent bugs", "API documentation"]
     )
+    team_id: Optional[str] = Field(None, description="Filter by team/workspace ID.", examples=["team_1", "9018752317"])
     space_id: Optional[str] = Field(None, description="Filter by space ID.", examples=["space_1", "456"])
     list_id: Optional[str] = Field(None, description="Filter by list ID.", examples=["list_1", "123"])
     statuses: Optional[List[str]] = Field(

--- a/clickup_mcp/mcp_server/task.py
+++ b/clickup_mcp/mcp_server/task.py
@@ -6,6 +6,7 @@ Tools:
 - task.set_custom_field / task.clear_custom_field
 - task.add_dependency
 - task.add_assignee / task.remove_assignee
+- task.search
 """
 
 from clickup_mcp.client import ClickUpAPIClientFactory
@@ -19,6 +20,7 @@ from clickup_mcp.mcp_server.models.inputs.task import (
     TaskGetInput,
     TaskListInListInput,
     TaskRemoveAssigneeInput,
+    TaskSearchInput,
     TaskSetCustomFieldInput,
     TaskUpdateInput,
 )
@@ -28,7 +30,7 @@ from clickup_mcp.mcp_server.models.outputs.task import (
     TaskListResult,
     TaskResult,
 )
-from clickup_mcp.models.dto.task import TaskListQuery, TaskResp
+from clickup_mcp.models.dto.task import TaskListQuery, TaskResp, TaskSearchQuery
 from clickup_mcp.models.mapping.task_mapper import TaskMapper
 
 from .app import mcp
@@ -491,3 +493,71 @@ async def task_remove_assignee(input: TaskRemoveAssigneeInput) -> OperationResul
     client = ClickUpAPIClientFactory.get()
     success = await client.task.remove_assignee(input.task_id, input.assignee_id)
     return OperationResult(ok=success)
+
+
+@mcp.tool(
+    title="Search Tasks",
+    name="task.search",
+    description=(
+        "Search tasks with natural language query and filters. "
+        "Supports text search combined with status, priority, assignee, and date filters. "
+        "HTTP: GET /team/{team_id}/task with query parameters."
+    ),
+    annotations={
+        "readOnlyHint": True,
+        "openWorldHint": True,
+    },
+)
+@handle_tool_errors
+async def task_search(input: TaskSearchInput) -> TaskListResult:
+    """
+    Search tasks with natural language query and filters.
+
+    API:
+        GET /team/{team_id}/task with query parameters
+
+    Args:
+        input: TaskSearchInput with query text and optional filters
+
+    Returns:
+        TaskListResult: List of matching tasks
+
+    Error Handling:
+        This function is wrapped by `@handle_tool_errors` and returns a ToolResponse at runtime.
+        On failure, `ok=False` with issues (e.g., VALIDATION_ERROR, NOT_FOUND, PERMISSION_DENIED).
+
+    Examples:
+        # Python (async)
+        response = await task_search(TaskSearchInput(query="urgent bugs", team_id="team_123", priorities=[1, 2]))
+        if response.ok and response.result:
+            for task in response.result.tasks:
+                print(task.name)
+    """
+    client = ClickUpAPIClientFactory.get()
+    # Input -> DTO
+    dto = TaskSearchQuery(
+        query=input.query,
+        team_id=input.team_id,
+        space_id=input.space_id,
+        list_id=input.list_id,
+        statuses=input.statuses,
+        priorities=input.priorities,
+        assignees=input.assignees,
+        due_date_from=input.due_date_from,
+        due_date_to=input.due_date_to,
+        page=input.page,
+        limit=input.limit,
+    )
+    query_params = dto.to_query()
+    async with client:
+        resp = await client.task.search(query_params)
+    if not resp:
+        raise ClickUpAPIError("Search tasks failed")
+    # DTO -> Domain -> Output
+    tasks = []
+    if hasattr(resp, "tasks") and resp.tasks:
+        for task_dto in resp.tasks:
+            domain = TaskMapper.to_domain(task_dto)
+            output = TaskMapper.to_task_result_output(domain, url=task_dto.url if hasattr(task_dto, "url") else None)
+            tasks.append(output)
+    return TaskListResult(tasks=tasks)


### PR DESCRIPTION
## Description
Implement task search API and MCP tool

## Changes
- Added search() method to TaskAPI for natural language search with filters
- Added task.search MCP tool for searching tasks with NLP query and structured filters
- Support for text search combined with status, priority, assignee, and date filters

## Related Tasks
- Task 2.9: Implement search API methods
- Task 2.10: Create task search MCP tool