### PR TITLE
[MCP-63] ✨ time: Add tracking models and domain logic

### DIFF
--- a/clickup_mcp/mcp_server/models/inputs/time.py
+++ b/clickup_mcp/mcp_server/models/inputs/time.py
@@ -48,15 +48,9 @@ class TimeEntryCreateInput(BaseModel):
     description: Optional[str] = Field(
         None, description="Description of the time entry.", examples=["Implementation work", "Bug fix"]
     )
-    start: Optional[int] = Field(
-        None, description="Start time in epoch ms.", examples=[1702080000000]
-    )
-    end: Optional[int] = Field(
-        None, description="End time in epoch ms.", examples=[1702083600000]
-    )
-    duration: Optional[int] = Field(
-        None, ge=0, description="Duration in milliseconds.", examples=[3600000, 7200000]
-    )
+    start: Optional[int] = Field(None, description="Start time in epoch ms.", examples=[1702080000000])
+    end: Optional[int] = Field(None, description="End time in epoch ms.", examples=[1702083600000])
+    duration: Optional[int] = Field(None, ge=0, description="Duration in milliseconds.", examples=[3600000, 7200000])
 
 
 class TimeEntryGetInput(BaseModel):
@@ -73,14 +67,10 @@ class TimeEntryGetInput(BaseModel):
         TimeEntryGetInput(team_id="team_1", time_entry_id="entry_123")
     """
 
-    model_config = ConfigDict(
-        json_schema_extra={"examples": [{"team_id": "team_1", "time_entry_id": "entry_123"}]}
-    )
+    model_config = ConfigDict(json_schema_extra={"examples": [{"team_id": "team_1", "time_entry_id": "entry_123"}]})
 
     team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["team_1", "9018752317"])
-    time_entry_id: str = Field(
-        ..., min_length=1, description="Time entry ID.", examples=["entry_123", "ent_abc"]
-    )
+    time_entry_id: str = Field(..., min_length=1, description="Time entry ID.", examples=["entry_123", "ent_abc"])
 
 
 class TimeEntryUpdateInput(BaseModel):
@@ -110,21 +100,11 @@ class TimeEntryUpdateInput(BaseModel):
     )
 
     team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["team_1", "9018752317"])
-    time_entry_id: str = Field(
-        ..., min_length=1, description="Time entry ID.", examples=["entry_123", "ent_abc"]
-    )
-    description: Optional[str] = Field(
-        None, description="New description.", examples=["Updated description"]
-    )
-    start: Optional[int] = Field(
-        None, description="New start time in epoch ms.", examples=[1702080000000]
-    )
-    end: Optional[int] = Field(
-        None, description="New end time in epoch ms.", examples=[1702087200000]
-    )
-    duration: Optional[int] = Field(
-        None, ge=0, description="New duration in milliseconds.", examples=[7200000]
-    )
+    time_entry_id: str = Field(..., min_length=1, description="Time entry ID.", examples=["entry_123", "ent_abc"])
+    description: Optional[str] = Field(None, description="New description.", examples=["Updated description"])
+    start: Optional[int] = Field(None, description="New start time in epoch ms.", examples=[1702080000000])
+    end: Optional[int] = Field(None, description="New end time in epoch ms.", examples=[1702087200000])
+    duration: Optional[int] = Field(None, ge=0, description="New duration in milliseconds.", examples=[7200000])
 
 
 class TimeEntryDeleteInput(BaseModel):
@@ -141,14 +121,10 @@ class TimeEntryDeleteInput(BaseModel):
         TimeEntryDeleteInput(team_id="team_1", time_entry_id="entry_123")
     """
 
-    model_config = ConfigDict(
-        json_schema_extra={"examples": [{"team_id": "team_1", "time_entry_id": "entry_123"}]}
-    )
+    model_config = ConfigDict(json_schema_extra={"examples": [{"team_id": "team_1", "time_entry_id": "entry_123"}]})
 
     team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["team_1", "9018752317"])
-    time_entry_id: str = Field(
-        ..., min_length=1, description="Time entry ID.", examples=["entry_123", "ent_abc"]
-    )
+    time_entry_id: str = Field(..., min_length=1, description="Time entry ID.", examples=["entry_123", "ent_abc"])
 
 
 class TimeEntryListInput(BaseModel):
@@ -178,18 +154,10 @@ class TimeEntryListInput(BaseModel):
     )
 
     team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["team_1", "9018752317"])
-    task_id: Optional[str] = Field(
-        None, description="Filter by task ID.", examples=["task_123", "tsk_abc"]
-    )
-    assignee: Optional[str] = Field(
-        None, description="Filter by user ID.", examples=["user_123", "usr_abc"]
-    )
-    start_date: Optional[int] = Field(
-        None, description="Filter by start date (epoch ms).", examples=[1702080000000]
-    )
-    end_date: Optional[int] = Field(
-        None, description="Filter by end date (epoch ms).", examples=[1702166400000]
-    )
+    task_id: Optional[str] = Field(None, description="Filter by task ID.", examples=["task_123", "tsk_abc"])
+    assignee: Optional[str] = Field(None, description="Filter by user ID.", examples=["user_123", "usr_abc"])
+    start_date: Optional[int] = Field(None, description="Filter by start date (epoch ms).", examples=[1702080000000])
+    end_date: Optional[int] = Field(None, description="Filter by end date (epoch ms).", examples=[1702166400000])
     page: int = Field(0, ge=0, description="Page number (0-indexed).", examples=[0, 1, 2])
     limit: int = Field(100, ge=1, le=100, description="Page size (cap 100).", examples=[25, 50, 100])
 
@@ -207,9 +175,7 @@ class TimeTrackingGetInput(BaseModel):
         TimeTrackingGetInput(task_id="task_123")
     """
 
-    model_config = ConfigDict(
-        json_schema_extra={"examples": [{"task_id": "task_123"}]}
-    )
+    model_config = ConfigDict(json_schema_extra={"examples": [{"task_id": "task_123"}]})
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "tsk_abc"])
 
@@ -227,9 +193,7 @@ class TimeTrackingStartInput(BaseModel):
         TimeTrackingStartInput(task_id="task_123")
     """
 
-    model_config = ConfigDict(
-        json_schema_extra={"examples": [{"task_id": "task_123"}]}
-    )
+    model_config = ConfigDict(json_schema_extra={"examples": [{"task_id": "task_123"}]})
 
     task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "tsk_abc"])
 

--- a/clickup_mcp/mcp_server/models/inputs/time.py
+++ b/clickup_mcp/mcp_server/models/inputs/time.py
@@ -1,0 +1,258 @@
+"""MCP input models for time tracking operations.
+
+High-signal schemas for FastMCP with constraints and examples.
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TimeEntryCreateInput(BaseModel):
+    """
+    Create a time entry for a task. HTTP: POST /team/{team_id}/time_entries
+
+    When to use: Log time spent on a specific task. You need the team ID and task ID.
+
+    Constraints:
+        - `duration` must be positive (milliseconds)
+        - Time fields are epoch milliseconds
+
+    Attributes:
+        team_id: Team/workspace ID
+        task_id: Task ID to log time against
+        description: Optional description of the time entry
+        start: Start time in epoch ms
+        end: End time in epoch ms (can be omitted if duration is provided)
+        duration: Duration in milliseconds (can be omitted if start/end are provided)
+
+    Examples:
+        TimeEntryCreateInput(team_id="team_1", task_id="task_123", description="Implementation work", duration=3600000)
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "team_id": "team_1",
+                    "task_id": "task_123",
+                    "description": "Implementation work",
+                    "duration": 3600000,
+                }
+            ]
+        }
+    )
+
+    team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["team_1", "9018752317"])
+    task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "tsk_abc"])
+    description: Optional[str] = Field(
+        None, description="Description of the time entry.", examples=["Implementation work", "Bug fix"]
+    )
+    start: Optional[int] = Field(
+        None, description="Start time in epoch ms.", examples=[1702080000000]
+    )
+    end: Optional[int] = Field(
+        None, description="End time in epoch ms.", examples=[1702083600000]
+    )
+    duration: Optional[int] = Field(
+        None, ge=0, description="Duration in milliseconds.", examples=[3600000, 7200000]
+    )
+
+
+class TimeEntryGetInput(BaseModel):
+    """
+    Get a time entry by ID. HTTP: GET /team/{team_id}/time_entries/{time_entry_id}
+
+    When to use: Retrieve details of a specific time entry.
+
+    Attributes:
+        team_id: Team/workspace ID
+        time_entry_id: Time entry ID
+
+    Examples:
+        TimeEntryGetInput(team_id="team_1", time_entry_id="entry_123")
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={"examples": [{"team_id": "team_1", "time_entry_id": "entry_123"}]}
+    )
+
+    team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["team_1", "9018752317"])
+    time_entry_id: str = Field(
+        ..., min_length=1, description="Time entry ID.", examples=["entry_123", "ent_abc"]
+    )
+
+
+class TimeEntryUpdateInput(BaseModel):
+    """
+    Update a time entry. HTTP: PUT /team/{team_id}/time_entries/{time_entry_id}
+
+    When to use: Modify time entry details like description, start, end, or duration.
+
+    Constraints:
+        - `duration` must be positive if provided
+        - Time fields are epoch milliseconds
+
+    Attributes:
+        team_id: Team/workspace ID
+        time_entry_id: Time entry ID
+        description: New description
+        start: New start time in epoch ms
+        end: New end time in epoch ms
+        duration: New duration in milliseconds
+
+    Examples:
+        TimeEntryUpdateInput(team_id="team_1", time_entry_id="entry_123", duration=7200000)
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={"examples": [{"team_id": "team_1", "time_entry_id": "entry_123", "duration": 7200000}]}
+    )
+
+    team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["team_1", "9018752317"])
+    time_entry_id: str = Field(
+        ..., min_length=1, description="Time entry ID.", examples=["entry_123", "ent_abc"]
+    )
+    description: Optional[str] = Field(
+        None, description="New description.", examples=["Updated description"]
+    )
+    start: Optional[int] = Field(
+        None, description="New start time in epoch ms.", examples=[1702080000000]
+    )
+    end: Optional[int] = Field(
+        None, description="New end time in epoch ms.", examples=[1702087200000]
+    )
+    duration: Optional[int] = Field(
+        None, ge=0, description="New duration in milliseconds.", examples=[7200000]
+    )
+
+
+class TimeEntryDeleteInput(BaseModel):
+    """
+    Delete a time entry. HTTP: DELETE /team/{team_id}/time_entries/{time_entry_id}
+
+    When to use: Remove a time entry permanently.
+
+    Attributes:
+        team_id: Team/workspace ID
+        time_entry_id: Time entry ID
+
+    Examples:
+        TimeEntryDeleteInput(team_id="team_1", time_entry_id="entry_123")
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={"examples": [{"team_id": "team_1", "time_entry_id": "entry_123"}]}
+    )
+
+    team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["team_1", "9018752317"])
+    time_entry_id: str = Field(
+        ..., min_length=1, description="Time entry ID.", examples=["entry_123", "ent_abc"]
+    )
+
+
+class TimeEntryListInput(BaseModel):
+    """
+    List time entries with filters. HTTP: GET /team/{team_id}/time_entries
+
+    When to use: Retrieve time entries with optional filtering by task, user, date range.
+
+    Constraints:
+        - `limit` ≤ 100 per API
+
+    Attributes:
+        team_id: Team/workspace ID
+        task_id: Filter by task ID
+        assignee: Filter by user ID
+        start_date: Filter by start date (epoch ms)
+        end_date: Filter by end date (epoch ms)
+        page: Page number (0-indexed)
+        limit: Page size (cap 100)
+
+    Examples:
+        TimeEntryListInput(team_id="team_1", task_id="task_123", limit=50)
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={"examples": [{"team_id": "team_1", "task_id": "task_123", "limit": 50}]}
+    )
+
+    team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["team_1", "9018752317"])
+    task_id: Optional[str] = Field(
+        None, description="Filter by task ID.", examples=["task_123", "tsk_abc"]
+    )
+    assignee: Optional[str] = Field(
+        None, description="Filter by user ID.", examples=["user_123", "usr_abc"]
+    )
+    start_date: Optional[int] = Field(
+        None, description="Filter by start date (epoch ms).", examples=[1702080000000]
+    )
+    end_date: Optional[int] = Field(
+        None, description="Filter by end date (epoch ms).", examples=[1702166400000]
+    )
+    page: int = Field(0, ge=0, description="Page number (0-indexed).", examples=[0, 1, 2])
+    limit: int = Field(100, ge=1, le=100, description="Page size (cap 100).", examples=[25, 50, 100])
+
+
+class TimeTrackingGetInput(BaseModel):
+    """
+    Get time tracking status for a task. HTTP: GET /task/{task_id}/time_tracking
+
+    When to use: Check if time tracking is currently active for a task.
+
+    Attributes:
+        task_id: Task ID
+
+    Examples:
+        TimeTrackingGetInput(task_id="task_123")
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={"examples": [{"task_id": "task_123"}]}
+    )
+
+    task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "tsk_abc"])
+
+
+class TimeTrackingStartInput(BaseModel):
+    """
+    Start time tracking for a task. HTTP: POST /task/{task_id}/time_tracking/start
+
+    When to use: Begin tracking time on a task.
+
+    Attributes:
+        task_id: Task ID
+
+    Examples:
+        TimeTrackingStartInput(task_id="task_123")
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={"examples": [{"task_id": "task_123"}]}
+    )
+
+    task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "tsk_abc"])
+
+
+class TimeTrackingStopInput(BaseModel):
+    """
+    Stop time tracking for a task. HTTP: POST /task/{task_id}/time_tracking/stop
+
+    When to use: End the current time tracking session on a task.
+
+    Attributes:
+        task_id: Task ID
+        description: Optional description for the time entry
+
+    Examples:
+        TimeTrackingStopInput(task_id="task_123", description="Completed implementation")
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={"examples": [{"task_id": "task_123", "description": "Completed implementation"}]}
+    )
+
+    task_id: str = Field(..., min_length=1, description="Task ID.", examples=["task_123", "tsk_abc"])
+    description: Optional[str] = Field(
+        None, description="Description for the time entry.", examples=["Completed implementation"]
+    )

--- a/clickup_mcp/models/domain/time.py
+++ b/clickup_mcp/models/domain/time.py
@@ -1,0 +1,283 @@
+"""
+Domain model for ClickUp Time Entry.
+
+Represents a Time Entry aggregate with business behaviors and invariants.
+References related aggregates by identity only (task_id, user_id, team_id);
+does not embed nested aggregates to maintain loose coupling.
+
+A Time Entry represents logged time spent on a task, including duration,
+description, and timing information.
+
+Domain Model Principles:
+- Represents the core business entity independent of transport details
+- Encapsulates business logic and invariants (e.g., duration validation)
+- References other aggregates by ID only (no embedded objects)
+- Provides behavior methods that enforce domain rules
+- Uses epoch milliseconds for time fields (vendor-agnostic)
+
+Usage Examples:
+    # Python - Create a time entry domain entity
+    from clickup_mcp.models.domain.time import TimeEntry
+
+    entry = TimeEntry(
+        id="entry_123",
+        task_id="task_456",
+        user_id="user_789",
+        team_id="team_001",
+        description="Implementation work",
+        duration=3600000,  # 1 hour in ms
+        start=1702080000000,
+        end=1702083600000
+    )
+
+    # Python - Use domain behaviors
+    entry.update_description("Updated description")
+    entry.set_duration(7200000)  # 2 hours
+    entry.adjust_timing(1702087200000, 1702090800000)
+"""
+
+from typing import Optional
+
+from pydantic import Field
+
+from .base import BaseDomainModel
+
+
+class TimeEntry(BaseDomainModel):
+    """
+    Domain model for a ClickUp Time Entry with core behaviors and invariants.
+
+    This model represents a time entry in ClickUp and includes all relevant fields
+    from the ClickUp API. A Time Entry tracks time spent on a task, including
+    duration, description, and timing information.
+
+    In ClickUp's hierarchy:
+    - Team (workspace) → Task → Time Entry
+
+    Attributes:
+        entry_id: The unique identifier for the time entry (aliased as 'id' for compatibility)
+        task_id: The ID of the task this time entry belongs to
+        user_id: The ID of the user who logged the time
+        team_id: The ID of the team/workspace
+        description: Description of the work done
+        start: Start time in epoch milliseconds
+        end: End time in epoch milliseconds
+        duration: Duration in milliseconds
+        billable: Whether the time entry is billable
+
+    Key Design Features:
+    - Backward-compatible 'id' property that returns entry_id
+    - Behavior methods that enforce domain invariants
+    - References other aggregates by ID only (no nested objects)
+    - Uses epoch milliseconds for time fields (vendor-agnostic)
+    - Immutable once created (inherited from BaseDomainModel)
+
+    Usage Examples:
+        # Python - Create from API response
+        from clickup_mcp.models.domain.time import TimeEntry
+
+        entry = TimeEntry(
+            id="entry_123",
+            task_id="task_456",
+            user_id="user_789",
+            team_id="team_001",
+            description="Implementation work",
+            duration=3600000,
+            start=1702080000000,
+            end=1702083600000
+        )
+
+        # Python - Use domain behaviors
+        entry.update_description("Updated description")
+        entry.set_duration(7200000)
+        entry.adjust_timing(1702087200000, 1702090800000)
+
+        # Python - Access entry properties
+        print(entry.description)  # "Updated description"
+        print(entry.duration)  # 7200000
+    """
+
+    entry_id: str = Field(alias="id", description="The unique identifier for the time entry")
+    task_id: str = Field(description="Task ID this time entry belongs to")
+    user_id: str = Field(description="User ID who logged the time")
+    team_id: str = Field(description="Team/workspace ID")
+    description: str | None = Field(default=None, description="Description of the work done")
+    start: int | None = Field(default=None, description="Start time in epoch milliseconds")
+    end: int | None = Field(default=None, description="End time in epoch milliseconds")
+    duration: int | None = Field(default=None, description="Duration in milliseconds")
+    billable: bool = Field(default=False, description="Whether the time entry is billable")
+
+    @property
+    def id(self) -> str:
+        """
+        Get the time entry ID for backward compatibility.
+
+        This property provides backward compatibility by allowing access
+        to the entry ID via the 'id' property, even though the field is
+        named 'entry_id'.
+
+        Returns:
+            str: The time entry ID (same as entry_id)
+
+        Usage Examples:
+            # Python - Access via backward-compatible id property
+            entry = TimeEntry(id="entry_123", task_id="task_456", user_id="user_789", team_id="team_001")
+            print(entry.id)  # "entry_123"
+            print(entry.entry_id)  # "entry_123" (same value)
+        """
+        return self.entry_id
+
+    # Behaviors / Invariants
+    def update_description(self, description: str | None) -> None:
+        """
+        Update the time entry description.
+
+        Updates the description to a new value. Accepts None to clear the description.
+        Validates that non-None description values are not empty strings.
+
+        Args:
+            description: The new description or None to clear
+
+        Raises:
+            ValueError: If description is an empty string
+
+        Usage Examples:
+            # Python - Update description
+            entry = TimeEntry(id="entry_123", task_id="task_456", user_id="user_789", team_id="team_001")
+            entry.update_description("Updated description")
+            print(entry.description)  # "Updated description"
+
+            # Python - Clear description
+            entry.update_description(None)
+            print(entry.description)  # None
+
+            # Python - Error on empty string
+            try:
+                entry.update_description("")  # Raises ValueError
+            except ValueError as e:
+                print(f"Error: {e}")
+        """
+        if description is not None and not description.strip():
+            raise ValueError("description cannot be empty string")
+        self.description = description
+
+    def set_duration(self, duration_ms: int | None) -> None:
+        """
+        Set the duration of the time entry.
+
+        Updates the duration in epoch milliseconds. Validates that
+        the duration is non-negative.
+
+        Args:
+            duration_ms: Duration in milliseconds, or None to clear
+
+        Raises:
+            ValueError: If duration_ms is negative
+
+        Usage Examples:
+            # Python - Set duration
+            entry = TimeEntry(id="entry_123", task_id="task_456", user_id="user_789", team_id="team_001")
+            entry.set_duration(3600000)  # 1 hour
+            print(entry.duration)  # 3600000
+
+            # Python - Clear duration
+            entry.set_duration(None)
+            print(entry.duration)  # None
+
+            # Python - Error on negative value
+            try:
+                entry.set_duration(-1000)  # Raises ValueError
+            except ValueError as e:
+                print(f"Error: {e}")
+        """
+        if duration_ms is not None and duration_ms < 0:
+            raise ValueError("duration must be non-negative epoch ms")
+        self.duration = duration_ms
+
+    def adjust_timing(self, start: int | None, end: int | None) -> None:
+        """
+        Adjust the start and end times of the time entry.
+
+        Sets the start and end times in epoch milliseconds. Validates that
+        the times are non-negative and that end is not before start (if both provided).
+
+        Args:
+            start: Start time in epoch milliseconds, or None to clear
+            end: End time in epoch milliseconds, or None to clear
+
+        Raises:
+            ValueError: If start or end is negative, or if end is before start
+
+        Usage Examples:
+            # Python - Adjust timing
+            entry = TimeEntry(id="entry_123", task_id="task_456", user_id="user_789", team_id="team_001")
+            entry.adjust_timing(1702080000000, 1702083600000)
+            print(entry.start)  # 1702080000000
+            print(entry.end)  # 1702083600000
+
+            # Python - Clear timing
+            entry.adjust_timing(None, None)
+            print(entry.start)  # None
+            print(entry.end)  # None
+
+            # Python - Error on end before start
+            try:
+                entry.adjust_timing(1702083600000, 1702080000000)  # Raises ValueError
+            except ValueError as e:
+                print(f"Error: {e}")
+        """
+        if start is not None and start < 0:
+            raise ValueError("start time must be non-negative epoch ms")
+        if end is not None and end < 0:
+            raise ValueError("end time must be non-negative epoch ms")
+        if start is not None and end is not None and end < start:
+            raise ValueError("end time cannot be before start time")
+
+        self.start = start
+        self.end = end
+
+        # Auto-calculate duration if both start and end are provided
+        if start is not None and end is not None:
+            self.duration = end - start
+
+    def set_billable(self, billable: bool) -> None:
+        """
+        Set whether the time entry is billable.
+
+        Updates the billable status of the time entry.
+
+        Args:
+            billable: Whether the time entry should be marked as billable
+
+        Usage Examples:
+            # Python - Mark as billable
+            entry = TimeEntry(id="entry_123", task_id="task_456", user_id="user_789", team_id="team_001")
+            entry.set_billable(True)
+            print(entry.billable)  # True
+
+            # Python - Mark as non-billable
+            entry.set_billable(False)
+            print(entry.billable)  # False
+        """
+        self.billable = billable
+
+    def is_active(self) -> bool:
+        """
+        Check if the time entry is currently active (has start time but no end time).
+
+        Returns:
+            bool: True if the time entry is active (started but not ended)
+
+        Usage Examples:
+            # Python - Check if active
+            entry = TimeEntry(id="entry_123", task_id="task_456", user_id="user_789", team_id="team_001", start=1702080000000)
+            print(entry.is_active())  # True
+
+            entry.adjust_timing(1702080000000, 1702083600000)
+            print(entry.is_active())  # False
+        """
+        return self.start is not None and self.end is None
+
+
+# Backwards compatibility alias
+TimeTrackingEntry = TimeEntry

--- a/clickup_mcp/models/domain/time.py
+++ b/clickup_mcp/models/domain/time.py
@@ -36,8 +36,6 @@ Usage Examples:
     entry.adjust_timing(1702087200000, 1702090800000)
 """
 
-from typing import Optional
-
 from pydantic import Field
 
 from .base import BaseDomainModel


### PR DESCRIPTION
## Summary
This PR adds time tracking input models and domain logic for Story 3 (Time Tracking & Reporting). It provides the foundational models needed for time entry operations.

## Changes
- **Input Models**: Added `time.py` with MCP input models for time tracking operations:
  - `TimeEntryCreateInput`: Create time entries
  - `TimeEntryGetInput`: Retrieve time entry details
  - `TimeEntryUpdateInput`: Update time entry details
  - `TimeEntryDeleteInput`: Delete time entries
  - `TimeEntryListInput`: List time entries with filters
  - `TimeTrackingGetInput`: Get time tracking status
  - `TimeTrackingStartInput`: Start time tracking
  - `TimeTrackingStopInput`: Stop time tracking

- **Domain Model**: Added `domain/time.py` with `TimeEntry` domain model:
  - Core fields: entry_id, task_id, user_id, team_id, description, start, end, duration, billable
  - Behaviors: update_description, set_duration, adjust_timing, set_billable, is_active
  - Invariants: Duration validation, time validation, description validation
  - Backward-compatible id property

## Linked Tasks
- Task 3.1: Time tracking input models
- Task 3.2: Time entry domain model with behaviors
- Task 3.3: Time tracking input validation

## Testing
- Input models follow existing pattern from task.py
- Domain model follows existing pattern from domain/task.py
- All models include comprehensive docstrings and examples

## Check
- [x] Code follows project style guidelines
- [x] Docstrings added for all new models
- [x] Examples provided in docstrings
- [x] ConfigDict used for Pydantic model configuration
- [x] Domain model includes behaviors and invariants
- [x] Backward-compatible id property added