### PR TITLE
[MCP-79] ✨ goal: Add CRUD models and domain logic

### DIFF
--- a/clickup_mcp/mcp_server/models/inputs/goal.py
+++ b/clickup_mcp/mcp_server/models/inputs/goal.py
@@ -45,7 +45,9 @@ class GoalCreateInput(BaseModel):
     )
 
     team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["team_1", "9018752317"])
-    name: str = Field(..., min_length=1, description="Goal name/title.", examples=["Q1 Revenue Goal", "Increase user retention"])
+    name: str = Field(
+        ..., min_length=1, description="Goal name/title.", examples=["Q1 Revenue Goal", "Increase user retention"]
+    )
     description: Optional[str] = Field(
         None, description="Description of the goal.", examples=["Achieve $1M in revenue", "Improve user onboarding"]
     )
@@ -53,8 +55,12 @@ class GoalCreateInput(BaseModel):
     key_results: Optional[list[str]] = Field(
         None, description="List of key result names.", examples=[["KR1", "KR2"], ["Increase MRR by 20%"]]
     )
-    multiple_owners: bool = Field(default=False, description="Whether multiple users can own this goal.", examples=[True, False])
-    owners: Optional[list[str]] = Field(None, description="List of user IDs who own this goal.", examples=[["user_1", "user_2"]])
+    multiple_owners: bool = Field(
+        default=False, description="Whether multiple users can own this goal.", examples=[True, False]
+    )
+    owners: Optional[list[str]] = Field(
+        None, description="List of user IDs who own this goal.", examples=[["user_1", "user_2"]]
+    )
 
 
 class GoalGetInput(BaseModel):
@@ -99,14 +105,18 @@ class GoalUpdateInput(BaseModel):
     """
 
     model_config = ConfigDict(
-        json_schema_extra={"examples": [{"goal_id": "goal_123", "name": "Updated Goal Name", "due_date": 1702166400000}]}
+        json_schema_extra={
+            "examples": [{"goal_id": "goal_123", "name": "Updated Goal Name", "due_date": 1702166400000}]
+        }
     )
 
     goal_id: str = Field(..., min_length=1, description="Goal ID.", examples=["goal_123", "gl_abc"])
     name: Optional[str] = Field(None, description="New goal name.", examples=["Updated Goal Name"])
     description: Optional[str] = Field(None, description="New description.", examples=["Updated description"])
     due_date: Optional[int] = Field(None, description="New due date in epoch ms.", examples=[1702166400000])
-    key_results: Optional[list[str]] = Field(None, description="New list of key result names.", examples=[["KR1", "KR2"]])
+    key_results: Optional[list[str]] = Field(
+        None, description="New list of key result names.", examples=[["KR1", "KR2"]]
+    )
     owners: Optional[list[str]] = Field(None, description="New list of user IDs.", examples=[["user_1", "user_2"]])
     status: Optional[str] = Field(None, description="New goal status.", examples=["active", "completed", "paused"])
 
@@ -154,7 +164,9 @@ class GoalListInput(BaseModel):
     model_config = ConfigDict(json_schema_extra={"examples": [{"team_id": "team_1", "status": "active", "limit": 50}]})
 
     team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["team_1", "9018752317"])
-    status: Optional[str] = Field(None, description="Filter by goal status.", examples=["active", "completed", "paused"])
+    status: Optional[str] = Field(
+        None, description="Filter by goal status.", examples=["active", "completed", "paused"]
+    )
     owner: Optional[str] = Field(None, description="Filter by user ID.", examples=["user_123", "usr_abc"])
     start_date: Optional[int] = Field(None, description="Filter by start date (epoch ms).", examples=[1702080000000])
     end_date: Optional[int] = Field(None, description="Filter by end date (epoch ms).", examples=[1702166400000])

--- a/clickup_mcp/mcp_server/models/inputs/goal.py
+++ b/clickup_mcp/mcp_server/models/inputs/goal.py
@@ -1,0 +1,162 @@
+"""MCP input models for goal CRUD operations.
+
+High-signal schemas for FastMCP with constraints and examples.
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class GoalCreateInput(BaseModel):
+    """
+    Create a goal for a team. HTTP: POST /team/{team_id}/goal
+
+    When to use: Create a new goal to track objectives and key results.
+
+    Constraints:
+        - `due_date` must be in the future (epoch milliseconds)
+        - Time fields are epoch milliseconds
+
+    Attributes:
+        team_id: Team/workspace ID
+        name: Goal name/title
+        description: Optional description of the goal
+        due_date: Due date in epoch ms
+        key_results: Optional list of key result names
+        multiple_owners: Whether multiple users can own this goal
+        owners: List of user IDs who own this goal
+
+    Examples:
+        GoalCreateInput(team_id="team_1", name="Q1 Revenue Goal", description="Achieve $1M in revenue", due_date=1702080000000)
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "team_id": "team_1",
+                    "name": "Q1 Revenue Goal",
+                    "description": "Achieve $1M in revenue",
+                    "due_date": 1702080000000,
+                }
+            ]
+        }
+    )
+
+    team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["team_1", "9018752317"])
+    name: str = Field(..., min_length=1, description="Goal name/title.", examples=["Q1 Revenue Goal", "Increase user retention"])
+    description: Optional[str] = Field(
+        None, description="Description of the goal.", examples=["Achieve $1M in revenue", "Improve user onboarding"]
+    )
+    due_date: int = Field(..., description="Due date in epoch ms.", examples=[1702080000000, 1702166400000])
+    key_results: Optional[list[str]] = Field(
+        None, description="List of key result names.", examples=[["KR1", "KR2"], ["Increase MRR by 20%"]]
+    )
+    multiple_owners: bool = Field(default=False, description="Whether multiple users can own this goal.", examples=[True, False])
+    owners: Optional[list[str]] = Field(None, description="List of user IDs who own this goal.", examples=[["user_1", "user_2"]])
+
+
+class GoalGetInput(BaseModel):
+    """
+    Get a goal by ID. HTTP: GET /goal/{goal_id}
+
+    When to use: Retrieve details of a specific goal.
+
+    Attributes:
+        goal_id: Goal ID
+
+    Examples:
+        GoalGetInput(goal_id="goal_123")
+    """
+
+    model_config = ConfigDict(json_schema_extra={"examples": [{"goal_id": "goal_123"}]})
+
+    goal_id: str = Field(..., min_length=1, description="Goal ID.", examples=["goal_123", "gl_abc"])
+
+
+class GoalUpdateInput(BaseModel):
+    """
+    Update a goal. HTTP: PUT /goal/{goal_id}
+
+    When to use: Modify goal details like name, description, due date, or owners.
+
+    Constraints:
+        - `due_date` must be in the future if provided
+        - Time fields are epoch milliseconds
+
+    Attributes:
+        goal_id: Goal ID
+        name: New goal name
+        description: New description
+        due_date: New due date in epoch ms
+        key_results: New list of key result names
+        owners: New list of user IDs who own this goal
+        status: New goal status
+
+    Examples:
+        GoalUpdateInput(goal_id="goal_123", name="Updated Goal Name", due_date=1702166400000)
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={"examples": [{"goal_id": "goal_123", "name": "Updated Goal Name", "due_date": 1702166400000}]}
+    )
+
+    goal_id: str = Field(..., min_length=1, description="Goal ID.", examples=["goal_123", "gl_abc"])
+    name: Optional[str] = Field(None, description="New goal name.", examples=["Updated Goal Name"])
+    description: Optional[str] = Field(None, description="New description.", examples=["Updated description"])
+    due_date: Optional[int] = Field(None, description="New due date in epoch ms.", examples=[1702166400000])
+    key_results: Optional[list[str]] = Field(None, description="New list of key result names.", examples=[["KR1", "KR2"]])
+    owners: Optional[list[str]] = Field(None, description="New list of user IDs.", examples=[["user_1", "user_2"]])
+    status: Optional[str] = Field(None, description="New goal status.", examples=["active", "completed", "paused"])
+
+
+class GoalDeleteInput(BaseModel):
+    """
+    Delete a goal. HTTP: DELETE /goal/{goal_id}
+
+    When to use: Remove a goal permanently.
+
+    Attributes:
+        goal_id: Goal ID
+
+    Examples:
+        GoalDeleteInput(goal_id="goal_123")
+    """
+
+    model_config = ConfigDict(json_schema_extra={"examples": [{"goal_id": "goal_123"}]})
+
+    goal_id: str = Field(..., min_length=1, description="Goal ID.", examples=["goal_123", "gl_abc"])
+
+
+class GoalListInput(BaseModel):
+    """
+    List goals for a team with filters. HTTP: GET /team/{team_id}/goal
+
+    When to use: Retrieve goals with optional filtering by status, owner, date range.
+
+    Constraints:
+        - `limit` ≤ 100 per API
+
+    Attributes:
+        team_id: Team/workspace ID
+        status: Filter by goal status
+        owner: Filter by user ID
+        start_date: Filter by start date (epoch ms)
+        end_date: Filter by end date (epoch ms)
+        page: Page number (0-indexed)
+        limit: Page size (cap 100)
+
+    Examples:
+        GoalListInput(team_id="team_1", status="active", limit=50)
+    """
+
+    model_config = ConfigDict(json_schema_extra={"examples": [{"team_id": "team_1", "status": "active", "limit": 50}]})
+
+    team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["team_1", "9018752317"])
+    status: Optional[str] = Field(None, description="Filter by goal status.", examples=["active", "completed", "paused"])
+    owner: Optional[str] = Field(None, description="Filter by user ID.", examples=["user_123", "usr_abc"])
+    start_date: Optional[int] = Field(None, description="Filter by start date (epoch ms).", examples=[1702080000000])
+    end_date: Optional[int] = Field(None, description="Filter by end date (epoch ms).", examples=[1702166400000])
+    page: int = Field(0, ge=0, description="Page number (0-indexed).", examples=[0, 1, 2])
+    limit: int = Field(100, ge=1, le=100, description="Page size (cap 100).", examples=[25, 50, 100])

--- a/clickup_mcp/models/domain/goal.py
+++ b/clickup_mcp/models/domain/goal.py
@@ -383,4 +383,5 @@ class Goal(BaseDomainModel):
         if self.due_date is None or self.status == "completed":
             return False
         import time
+
         return self.due_date < int(time.time() * 1000)

--- a/clickup_mcp/models/domain/goal.py
+++ b/clickup_mcp/models/domain/goal.py
@@ -1,0 +1,386 @@
+"""
+Domain model for ClickUp Goal.
+
+Represents a Goal aggregate with business behaviors and invariants.
+References related aggregates by identity only (team_id, owner_id);
+does not embed nested aggregates to maintain loose coupling.
+
+A Goal represents a high-level objective that can be tracked with key results.
+Goals are part of ClickUp's OKR (Objectives and Key Results) framework.
+
+Domain Model Principles:
+- Represents the core business entity independent of transport details
+- Encapsulates business logic and invariants (e.g., due date validation)
+- References other aggregates by ID only (no embedded objects)
+- Provides behavior methods that enforce domain rules
+- Uses epoch milliseconds for time fields (vendor-agnostic)
+
+Usage Examples:
+    # Python - Create a goal domain entity
+    from clickup_mcp.models.domain.goal import Goal
+
+    goal = Goal(
+        id="goal_123",
+        team_id="team_001",
+        name="Q1 Revenue Goal",
+        description="Achieve $1M in revenue",
+        due_date=1702080000000,
+        status="active"
+    )
+
+    # Python - Use domain behaviors
+    goal.update_name("Updated Goal Name")
+    goal.set_status("completed")
+    goal.set_due_date(1702166400000)
+"""
+
+from pydantic import Field
+
+from .base import BaseDomainModel
+
+
+class Goal(BaseDomainModel):
+    """
+    Domain model for a ClickUp Goal with core behaviors and invariants.
+
+    This model represents a goal in ClickUp and includes all relevant fields
+    from the ClickUp API. A Goal tracks high-level objectives that can be
+    measured with key results.
+
+    In ClickUp's hierarchy:
+    - Team (workspace) → Goal
+
+    Attributes:
+        goal_id: The unique identifier for the goal (aliased as 'id' for compatibility)
+        team_id: The ID of the team/workspace this goal belongs to
+        name: Goal name/title
+        description: Description of the goal
+        due_date: Due date in epoch milliseconds
+        status: Goal status (e.g., "active", "completed", "paused")
+        key_results: List of key result names
+        owners: List of user IDs who own this goal
+        multiple_owners: Whether multiple users can own this goal
+        date_created: Creation date in epoch milliseconds
+        date_updated: Last update date in epoch milliseconds
+
+    Key Design Features:
+    - Backward-compatible 'id' property that returns goal_id
+    - Behavior methods that enforce domain invariants
+    - References other aggregates by ID only (no nested objects)
+    - Uses epoch milliseconds for time fields (vendor-agnostic)
+    - Immutable once created (inherited from BaseDomainModel)
+
+    Usage Examples:
+        # Python - Create from API response
+        from clickup_mcp.models.domain.goal import Goal
+
+        goal = Goal(
+            id="goal_123",
+            team_id="team_001",
+            name="Q1 Revenue Goal",
+            description="Achieve $1M in revenue",
+            due_date=1702080000000,
+            status="active"
+        )
+
+        # Python - Use domain behaviors
+        goal.update_name("Updated Goal Name")
+        goal.set_status("completed")
+        goal.set_due_date(1702166400000)
+
+        # Python - Access goal properties
+        print(goal.name)  # "Updated Goal Name"
+        print(goal.status)  # "completed"
+    """
+
+    goal_id: str = Field(alias="id", description="The unique identifier for the goal")
+    team_id: str = Field(description="Team/workspace ID this goal belongs to")
+    name: str = Field(description="Goal name/title")
+    description: str | None = Field(default=None, description="Description of the goal")
+    due_date: int | None = Field(default=None, description="Due date in epoch milliseconds")
+    status: str = Field(default="active", description="Goal status (e.g., 'active', 'completed', 'paused')")
+    key_results: list[str] = Field(default_factory=list, description="List of key result names")
+    owners: list[str] = Field(default_factory=list, description="List of user IDs who own this goal")
+    multiple_owners: bool = Field(default=False, description="Whether multiple users can own this goal")
+    date_created: int | None = Field(default=None, description="Creation date in epoch milliseconds")
+    date_updated: int | None = Field(default=None, description="Last update date in epoch milliseconds")
+
+    @property
+    def id(self) -> str:
+        """
+        Get the goal ID for backward compatibility.
+
+        This property provides backward compatibility by allowing access
+        to the goal ID via the 'id' property, even though the field is
+        named 'goal_id'.
+
+        Returns:
+            str: The goal ID (same as goal_id)
+
+        Usage Examples:
+            # Python - Access via backward-compatible id property
+            goal = Goal(id="goal_123", team_id="team_001", name="Q1 Revenue Goal")
+            print(goal.id)  # "goal_123"
+            print(goal.goal_id)  # "goal_123" (same value)
+        """
+        return self.goal_id
+
+    # Behaviors / Invariants
+    def update_name(self, name: str) -> None:
+        """
+        Update the goal name.
+
+        Updates the name to a new value. Validates that the name is not empty.
+
+        Args:
+            name: The new goal name
+
+        Raises:
+            ValueError: If name is an empty string
+
+        Usage Examples:
+            # Python - Update name
+            goal = Goal(id="goal_123", team_id="team_001", name="Q1 Revenue Goal")
+            goal.update_name("Updated Goal Name")
+            print(goal.name)  # "Updated Goal Name"
+
+            # Python - Error on empty string
+            try:
+                goal.update_name("")  # Raises ValueError
+            except ValueError as e:
+                print(f"Error: {e}")
+        """
+        if not name.strip():
+            raise ValueError("name cannot be empty string")
+        self.name = name
+
+    def update_description(self, description: str | None) -> None:
+        """
+        Update the goal description.
+
+        Updates the description to a new value. Accepts None to clear the description.
+        Validates that non-None description values are not empty strings.
+
+        Args:
+            description: The new description or None to clear
+
+        Raises:
+            ValueError: If description is an empty string
+
+        Usage Examples:
+            # Python - Update description
+            goal = Goal(id="goal_123", team_id="team_001", name="Q1 Revenue Goal")
+            goal.update_description("Updated description")
+            print(goal.description)  # "Updated description"
+
+            # Python - Clear description
+            goal.update_description(None)
+            print(goal.description)  # None
+        """
+        if description is not None and not description.strip():
+            raise ValueError("description cannot be empty string")
+        self.description = description
+
+    def set_status(self, status: str) -> None:
+        """
+        Set the goal status.
+
+        Updates the goal status. Validates that the status is one of the valid values.
+
+        Args:
+            status: The new status (e.g., "active", "completed", "paused")
+
+        Raises:
+            ValueError: If status is not a valid value
+
+        Usage Examples:
+            # Python - Set status
+            goal = Goal(id="goal_123", team_id="team_001", name="Q1 Revenue Goal")
+            goal.set_status("completed")
+            print(goal.status)  # "completed"
+        """
+        valid_statuses = {"active", "completed", "paused", "archived"}
+        if status not in valid_statuses:
+            raise ValueError(f"status must be one of {valid_statuses}")
+        self.status = status
+
+    def set_due_date(self, due_date: int | None) -> None:
+        """
+        Set the due date of the goal.
+
+        Updates the due date in epoch milliseconds. Validates that
+        the due date is non-negative.
+
+        Args:
+            due_date: Due date in epoch milliseconds, or None to clear
+
+        Raises:
+            ValueError: If due_date is negative
+
+        Usage Examples:
+            # Python - Set due date
+            goal = Goal(id="goal_123", team_id="team_001", name="Q1 Revenue Goal")
+            goal.set_due_date(1702080000000)
+            print(goal.due_date)  # 1702080000000
+
+            # Python - Clear due date
+            goal.set_due_date(None)
+            print(goal.due_date)  # None
+
+            # Python - Error on negative value
+            try:
+                goal.set_due_date(-1000)  # Raises ValueError
+            except ValueError as e:
+                print(f"Error: {e}")
+        """
+        if due_date is not None and due_date < 0:
+            raise ValueError("due_date must be non-negative epoch ms")
+        self.due_date = due_date
+
+    def add_key_result(self, key_result: str) -> None:
+        """
+        Add a key result to the goal.
+
+        Adds a new key result to the goal's key results list.
+
+        Args:
+            key_result: The key result name to add
+
+        Raises:
+            ValueError: If key_result is an empty string or already exists
+
+        Usage Examples:
+            # Python - Add key result
+            goal = Goal(id="goal_123", team_id="team_001", name="Q1 Revenue Goal")
+            goal.add_key_result("Increase MRR by 20%")
+            print(goal.key_results)  # ["Increase MRR by 20%"]
+        """
+        if not key_result.strip():
+            raise ValueError("key_result cannot be empty string")
+        if key_result in self.key_results:
+            raise ValueError(f"key_result '{key_result}' already exists")
+        self.key_results.append(key_result)
+
+    def remove_key_result(self, key_result: str) -> None:
+        """
+        Remove a key result from the goal.
+
+        Removes a key result from the goal's key results list.
+
+        Args:
+            key_result: The key result name to remove
+
+        Raises:
+            ValueError: If key_result is not in the list
+
+        Usage Examples:
+            # Python - Remove key result
+            goal = Goal(id="goal_123", team_id="team_001", name="Q1 Revenue Goal")
+            goal.add_key_result("Increase MRR by 20%")
+            goal.remove_key_result("Increase MRR by 20%")
+            print(goal.key_results)  # []
+        """
+        if key_result not in self.key_results:
+            raise ValueError(f"key_result '{key_result}' not found")
+        self.key_results.remove(key_result)
+
+    def add_owner(self, owner_id: str) -> None:
+        """
+        Add an owner to the goal.
+
+        Adds a new owner to the goal's owners list.
+
+        Args:
+            owner_id: The user ID to add as an owner
+
+        Raises:
+            ValueError: If owner_id is an empty string or already exists
+
+        Usage Examples:
+            # Python - Add owner
+            goal = Goal(id="goal_123", team_id="team_001", name="Q1 Revenue Goal")
+            goal.add_owner("user_123")
+            print(goal.owners)  # ["user_123"]
+        """
+        if not owner_id.strip():
+            raise ValueError("owner_id cannot be empty string")
+        if owner_id in self.owners:
+            raise ValueError(f"owner_id '{owner_id}' already exists")
+        if not self.multiple_owners and self.owners:
+            raise ValueError("cannot add multiple owners when multiple_owners is False")
+        self.owners.append(owner_id)
+
+    def remove_owner(self, owner_id: str) -> None:
+        """
+        Remove an owner from the goal.
+
+        Removes an owner from the goal's owners list.
+
+        Args:
+            owner_id: The user ID to remove
+
+        Raises:
+            ValueError: If owner_id is not in the list
+
+        Usage Examples:
+            # Python - Remove owner
+            goal = Goal(id="goal_123", team_id="team_001", name="Q1 Revenue Goal")
+            goal.add_owner("user_123")
+            goal.remove_owner("user_123")
+            print(goal.owners)  # []
+        """
+        if owner_id not in self.owners:
+            raise ValueError(f"owner_id '{owner_id}' not found")
+        self.owners.remove(owner_id)
+
+    def is_active(self) -> bool:
+        """
+        Check if the goal is currently active.
+
+        Returns:
+            bool: True if the goal status is "active"
+
+        Usage Examples:
+            # Python - Check if active
+            goal = Goal(id="goal_123", team_id="team_001", name="Q1 Revenue Goal", status="active")
+            print(goal.is_active())  # True
+
+            goal.set_status("completed")
+            print(goal.is_active())  # False
+        """
+        return self.status == "active"
+
+    def is_completed(self) -> bool:
+        """
+        Check if the goal is completed.
+
+        Returns:
+            bool: True if the goal status is "completed"
+
+        Usage Examples:
+            # Python - Check if completed
+            goal = Goal(id="goal_123", team_id="team_001", name="Q1 Revenue Goal", status="completed")
+            print(goal.is_completed())  # True
+
+            goal.set_status("active")
+            print(goal.is_completed())  # False
+        """
+        return self.status == "completed"
+
+    def is_overdue(self) -> bool:
+        """
+        Check if the goal is overdue (past due date and not completed).
+
+        Returns:
+            bool: True if the goal is overdue
+
+        Usage Examples:
+            # Python - Check if overdue
+            import time
+            goal = Goal(id="goal_123", team_id="team_001", name="Q1 Revenue Goal", due_date=int(time.time() * 1000) - 100000)
+            print(goal.is_overdue())  # True (if due date is in the past and not completed)
+        """
+        if self.due_date is None or self.status == "completed":
+            return False
+        import time
+        return self.due_date < int(time.time() * 1000)

--- a/clickup_mcp/models/domain/goal_factory.py
+++ b/clickup_mcp/models/domain/goal_factory.py
@@ -1,0 +1,182 @@
+"""
+Factory for creating Goal domain entities with validation.
+
+Provides factory methods to create Goal instances with business rule validation.
+This separates the creation logic from the domain model itself, following
+the Factory pattern.
+"""
+
+from typing import Optional
+
+from .goal import Goal
+
+
+class GoalFactory:
+    """
+    Factory for creating Goal domain entities with validation.
+
+    Provides static methods to create Goal instances with business rule validation.
+    This ensures that all Goal instances are created with valid data according
+    to domain rules.
+
+    Usage Examples:
+        # Python - Create a goal with factory
+        from clickup_mcp.models.domain.goal_factory import GoalFactory
+
+        goal = GoalFactory.create(
+            goal_id="goal_123",
+            team_id="team_001",
+            name="Q1 Revenue Goal",
+            due_date=1702080000000
+        )
+    """
+
+    @staticmethod
+    def create(
+        goal_id: str,
+        team_id: str,
+        name: str,
+        description: Optional[str] = None,
+        due_date: Optional[int] = None,
+        status: str = "active",
+        key_results: Optional[list[str]] = None,
+        owners: Optional[list[str]] = None,
+        multiple_owners: bool = False,
+        date_created: Optional[int] = None,
+        date_updated: Optional[int] = None,
+    ) -> Goal:
+        """
+        Create a Goal instance with validation.
+
+        Creates a Goal domain entity after validating the input data according
+        to business rules.
+
+        Args:
+            goal_id: The unique identifier for the goal
+            team_id: Team/workspace ID this goal belongs to
+            name: Goal name/title
+            description: Description of the goal
+            due_date: Due date in epoch milliseconds
+            status: Goal status (default: "active")
+            key_results: List of key result names
+            owners: List of user IDs who own this goal
+            multiple_owners: Whether multiple users can own this goal
+            date_created: Creation date in epoch milliseconds
+            date_updated: Last update date in epoch milliseconds
+
+        Returns:
+            Goal: A validated Goal domain entity
+
+        Raises:
+            ValueError: If validation fails
+
+        Usage Examples:
+            # Python - Create a goal with factory
+            goal = GoalFactory.create(
+                goal_id="goal_123",
+                team_id="team_001",
+                name="Q1 Revenue Goal",
+                due_date=1702080000000
+            )
+        """
+        # Validate required fields
+        if not goal_id.strip():
+            raise ValueError("goal_id cannot be empty string")
+        if not team_id.strip():
+            raise ValueError("team_id cannot be empty string")
+        if not name.strip():
+            raise ValueError("name cannot be empty string")
+
+        # Validate status
+        valid_statuses = {"active", "completed", "paused", "archived"}
+        if status not in valid_statuses:
+            raise ValueError(f"status must be one of {valid_statuses}")
+
+        # Validate due_date
+        if due_date is not None and due_date < 0:
+            raise ValueError("due_date must be non-negative epoch ms")
+
+        # Validate multiple_owners constraint
+        if not multiple_owners and owners and len(owners) > 1:
+            raise ValueError("cannot have multiple owners when multiple_owners is False")
+
+        # Validate no duplicate owners
+        if owners:
+            unique_owners = set(owners)
+            if len(unique_owners) != len(owners):
+                raise ValueError("owners must be unique")
+
+        # Validate no duplicate key results
+        if key_results:
+            unique_krs = set(key_results)
+            if len(unique_krs) != len(key_results):
+                raise ValueError("key_results must be unique")
+
+        # Create and return the Goal instance
+        return Goal(
+            id=goal_id,
+            team_id=team_id,
+            name=name,
+            description=description,
+            due_date=due_date,
+            status=status,
+            key_results=key_results or [],
+            owners=owners or [],
+            multiple_owners=multiple_owners,
+            date_created=date_created,
+            date_updated=date_updated,
+        )
+
+    @staticmethod
+    def from_dict(data: dict) -> Goal:
+        """
+        Create a Goal instance from a dictionary.
+
+        Creates a Goal domain entity from a dictionary, typically from API responses.
+
+        Args:
+            data: Dictionary containing goal data
+
+        Returns:
+            Goal: A validated Goal domain entity
+
+        Raises:
+            ValueError: If validation fails or required fields are missing
+
+        Usage Examples:
+            # Python - Create from dictionary
+            data = {
+                "id": "goal_123",
+                "team_id": "team_001",
+                "name": "Q1 Revenue Goal",
+                "due_date": 1702080000000
+            }
+            goal = GoalFactory.from_dict(data)
+        """
+        # Extract and validate required fields
+        goal_id = data.get("id") or data.get("goal_id")
+        if not goal_id:
+            raise ValueError("goal_id is required")
+
+        team_id = data.get("team_id")
+        if not team_id:
+            raise ValueError("team_id is required")
+
+        name = data.get("name")
+        if not name:
+            raise ValueError("name is required")
+
+        # Create the Goal instance
+        return GoalFactory.create(
+            goal_id=goal_id,
+            team_id=team_id,
+            name=name,
+            description=data.get("description"),
+            due_date=data.get("due_date"),
+            status=data.get("status", "active"),
+            key_results=data.get("key_results", []),
+            owners=data.get("owners", []),
+            multiple_owners=data.get("multiple_owners", False),
+            date_created=data.get("date_created"),
+            date_updated=data.get("date_updated"),
+        )


### PR DESCRIPTION
## Description
Add goal CRUD input models and domain logic for the Goal Management feature.

## Changes
- Created `clickup_mcp/mcp_server/models/inputs/goal.py` with input models for goal CRUD operations (create, get, update, delete, list)
- Created `clickup_mcp/models/domain/goal.py` with the Goal domain model including business logic and invariants
- Created `clickup_mcp/models/domain/goal_factory.py` with factory methods for creating Goal instances with validation

## Linked Tasks
- Task 4.1: Goal CRUD input models
- Task 4.2: Goal domain models
- Task 4.3: Goal domain logic

## Testing
- Manual verification of model structure and validation
- Follows existing patterns from time tracking models

## Checklist
- [x] Code follows project style guidelines
- [x] Includes comprehensive docstrings and examples
- [x] Follows Domain-Driven Design principles
- [x] Includes business logic and invariants in domain model