### PR TITLE
[MCP-99] ✨ workflow: Add automation models

### DIFF
--- a/clickup_mcp/mcp_server/models/inputs/workflow.py
+++ b/clickup_mcp/mcp_server/models/inputs/workflow.py
@@ -4,7 +4,7 @@ These inputs are LLM-friendly contracts used by FastMCP tools. They map to
 Domain entities first, then DTOs for ClickUp wire format.
 """
 
-from typing import List, Literal, Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -55,13 +55,18 @@ class WorkflowCreateInput(BaseModel):
         None, description="Description of the automation.", examples=["Auto-assign tasks when created in list 456"]
     )
     trigger_type: str = Field(
-        ..., min_length=1, description="Type of trigger (e.g., task_created, status_changed).", examples=["task_created", "status_changed"]
+        ...,
+        min_length=1,
+        description="Type of trigger (e.g., task_created, status_changed).",
+        examples=["task_created", "status_changed"],
     )
     trigger_config: Optional[dict] = Field(
         None, description="Configuration for the trigger.", examples=[{"list_id": "456"}, {"status": "done"}]
     )
     actions: List[dict] = Field(
-        default_factory=list, description="List of actions to execute.", examples=[[{"type": "assign", "user_id": "789"}]]
+        default_factory=list,
+        description="List of actions to execute.",
+        examples=[[{"type": "assign", "user_id": "789"}]],
     )
     is_active: bool = Field(True, description="Whether the workflow is active.", examples=[True, False])
     priority: Optional[int] = Field(None, description="Execution priority.", examples=[1, 2, 3])
@@ -96,15 +101,9 @@ class WorkflowUpdateInput(BaseModel):
     )
 
     workflow_id: str = Field(..., min_length=1, description="Workflow automation ID.", examples=["wf_123"])
-    name: Optional[str] = Field(
-        None, min_length=1, description="New workflow name.", examples=["Updated name"]
-    )
-    description: Optional[str] = Field(
-        None, description="New description.", examples=["Updated description"]
-    )
-    trigger_type: Optional[str] = Field(
-        None, description="New trigger type.", examples=["status_changed"]
-    )
+    name: Optional[str] = Field(None, min_length=1, description="New workflow name.", examples=["Updated name"])
+    description: Optional[str] = Field(None, description="New description.", examples=["Updated description"])
+    trigger_type: Optional[str] = Field(None, description="New trigger type.", examples=["status_changed"])
     trigger_config: Optional[dict] = Field(
         None, description="New trigger configuration.", examples=[{"status": "done"}]
     )

--- a/clickup_mcp/mcp_server/models/inputs/workflow.py
+++ b/clickup_mcp/mcp_server/models/inputs/workflow.py
@@ -1,0 +1,197 @@
+"""MCP input models for workflow automation operations.
+
+These inputs are LLM-friendly contracts used by FastMCP tools. They map to
+Domain entities first, then DTOs for ClickUp wire format.
+"""
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WorkflowCreateInput(BaseModel):
+    """
+    Create a workflow automation. HTTP: POST /team/{team_id}/workflow
+
+    When to use: Create an automation rule that triggers actions based on events.
+
+    Constraints:
+        - `trigger_type` must be a valid ClickUp trigger type
+        - At least one action must be specified
+        - Time fields are epoch milliseconds
+
+    Attributes:
+        team_id: Team/workspace ID
+        name: Workflow automation name
+        description: Description of the automation
+        trigger_type: Type of trigger (e.g., task_created, status_changed)
+        trigger_config: Configuration for the trigger
+        actions: List of actions to execute
+        is_active: Whether the workflow is active
+        priority: Execution priority
+
+    Examples:
+        WorkflowCreateInput(team_id="123", name="Auto-assign on create", trigger_type="task_created")
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "team_id": "123",
+                    "name": "Auto-assign on create",
+                    "trigger_type": "task_created",
+                    "trigger_config": {"list_id": "456"},
+                    "actions": [{"type": "assign", "user_id": "789"}],
+                    "is_active": True,
+                }
+            ]
+        }
+    )
+
+    team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["123", "team_1"])
+    name: str = Field(..., min_length=1, description="Workflow automation name.", examples=["Auto-assign on create"])
+    description: Optional[str] = Field(
+        None, description="Description of the automation.", examples=["Auto-assign tasks when created in list 456"]
+    )
+    trigger_type: str = Field(
+        ..., min_length=1, description="Type of trigger (e.g., task_created, status_changed).", examples=["task_created", "status_changed"]
+    )
+    trigger_config: Optional[dict] = Field(
+        None, description="Configuration for the trigger.", examples=[{"list_id": "456"}, {"status": "done"}]
+    )
+    actions: List[dict] = Field(
+        default_factory=list, description="List of actions to execute.", examples=[[{"type": "assign", "user_id": "789"}]]
+    )
+    is_active: bool = Field(True, description="Whether the workflow is active.", examples=[True, False])
+    priority: Optional[int] = Field(None, description="Execution priority.", examples=[1, 2, 3])
+
+
+class WorkflowUpdateInput(BaseModel):
+    """
+    Update a workflow automation. HTTP: PUT /workflow/{workflow_id}
+
+    When to use: Modify an existing workflow automation's configuration.
+
+    Attributes:
+        workflow_id: Workflow automation ID
+        name: New workflow name
+        description: New description
+        trigger_type: New trigger type
+        trigger_config: New trigger configuration
+        actions: New list of actions
+        is_active: New active status
+        priority: New priority
+
+    Examples:
+        WorkflowUpdateInput(workflow_id="wf_123", name="Updated name", is_active=False)
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {"workflow_id": "wf_123", "name": "Updated name", "is_active": False},
+            ]
+        }
+    )
+
+    workflow_id: str = Field(..., min_length=1, description="Workflow automation ID.", examples=["wf_123"])
+    name: Optional[str] = Field(
+        None, min_length=1, description="New workflow name.", examples=["Updated name"]
+    )
+    description: Optional[str] = Field(
+        None, description="New description.", examples=["Updated description"]
+    )
+    trigger_type: Optional[str] = Field(
+        None, description="New trigger type.", examples=["status_changed"]
+    )
+    trigger_config: Optional[dict] = Field(
+        None, description="New trigger configuration.", examples=[{"status": "done"}]
+    )
+    actions: Optional[List[dict]] = Field(
+        None, description="New list of actions.", examples=[[{"type": "assign", "user_id": "789"}]]
+    )
+    is_active: Optional[bool] = Field(None, description="New active status.", examples=[True, False])
+    priority: Optional[int] = Field(None, description="New priority.", examples=[1, 2, 3])
+
+
+class WorkflowGetInput(BaseModel):
+    """
+    Get a workflow automation. HTTP: GET /workflow/{workflow_id}
+
+    When to use: Retrieve details of a specific workflow automation.
+
+    Attributes:
+        workflow_id: Workflow automation ID
+
+    Examples:
+        WorkflowGetInput(workflow_id="wf_123")
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {"workflow_id": "wf_123"},
+            ]
+        }
+    )
+
+    workflow_id: str = Field(..., min_length=1, description="Workflow automation ID.", examples=["wf_123"])
+
+
+class WorkflowDeleteInput(BaseModel):
+    """
+    Delete a workflow automation. HTTP: DELETE /workflow/{workflow_id}
+
+    When to use: Remove a workflow automation.
+
+    Attributes:
+        workflow_id: Workflow automation ID
+
+    Examples:
+        WorkflowDeleteInput(workflow_id="wf_123")
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {"workflow_id": "wf_123"},
+            ]
+        }
+    )
+
+    workflow_id: str = Field(..., min_length=1, description="Workflow automation ID.", examples=["wf_123"])
+
+
+class WorkflowListInput(BaseModel):
+    """
+    List workflow automations. HTTP: GET /team/{team_id}/workflow
+
+    When to use: Retrieve all workflow automations for a team.
+
+    Constraints:
+        - `limit` ≤ 100 per API
+
+    Attributes:
+        team_id: Team/workspace ID
+        page: Page number (0-indexed)
+        limit: Page size (cap 100)
+        is_active: Filter by active status
+
+    Examples:
+        WorkflowListInput(team_id="123", limit=50)
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {"team_id": "123", "limit": 50},
+                {"team_id": "123", "is_active": True},
+            ]
+        }
+    )
+
+    team_id: str = Field(..., min_length=1, description="Team/workspace ID.", examples=["123", "team_1"])
+    page: int = Field(0, ge=0, description="Page number (0-indexed).", examples=[0, 1, 2])
+    limit: int = Field(100, ge=1, le=100, description="Page size (cap 100 by API).", examples=[25, 50, 100])
+    is_active: Optional[bool] = Field(None, description="Filter by active status.", examples=[True, False])

--- a/clickup_mcp/models/domain/__init__.py
+++ b/clickup_mcp/models/domain/__init__.py
@@ -6,10 +6,13 @@ in the ClickUp MCP application.
 """
 
 from .folder import ClickUpFolder, Folder
+from .goal import Goal
+from .key_result import KeyResult
 from .list import ClickUpList, List
 from .space import ClickUpSpace, Space
 from .task import ClickUpTask, Task
 from .team import ClickUpTeam, ClickUpTeamMember, ClickUpUser, Team
+from .workflow import Workflow
 
 __all__ = [
     # Space models
@@ -29,4 +32,10 @@ __all__ = [
     "ClickUpTeamMember",
     "ClickUpUser",
     "Team",  # Backwards compatibility alias
+    # Goal models
+    "Goal",
+    # Key result models
+    "KeyResult",
+    # Workflow models
+    "Workflow",
 ]

--- a/clickup_mcp/models/domain/workflow.py
+++ b/clickup_mcp/models/domain/workflow.py
@@ -1,0 +1,354 @@
+"""
+Domain model for ClickUp Workflow Automation.
+
+Represents a Workflow Automation aggregate with business behaviors and invariants.
+References related aggregates by identity only (team_id);
+does not embed nested aggregates to maintain loose coupling.
+
+A Workflow Automation is a rule that triggers actions based on events in ClickUp.
+It allows for automating repetitive tasks and maintaining consistent processes.
+
+Domain Model Principles:
+- Represents the core business entity independent of transport details
+- Encapsulates business logic and invariants (e.g., trigger validation)
+- References other aggregates by ID only (no embedded objects)
+- Provides behavior methods that enforce domain rules
+- Uses epoch milliseconds for time fields (vendor-agnostic)
+
+Usage Examples:
+    # Python - Create a workflow domain entity
+    from clickup_mcp.models.domain.workflow import Workflow
+
+    workflow = Workflow(
+        id="wf_123",
+        team_id="team_001",
+        name="Auto-assign on create",
+        trigger_type="task_created",
+        trigger_config={"list_id": "456"},
+        actions=[{"type": "assign", "user_id": "789"}]
+    )
+
+    # Python - Use domain behaviors
+    workflow.activate()
+    workflow.deactivate()
+    workflow.update_name("Updated name")
+"""
+
+from typing import List
+
+from pydantic import Field
+
+from .base import BaseDomainModel
+
+
+class Workflow(BaseDomainModel):
+    """
+    Domain model for a ClickUp Workflow Automation with core behaviors and invariants.
+
+    This model represents a workflow automation in ClickUp and includes all relevant fields
+    from the ClickUp API. A Workflow Automation is a rule that triggers actions based on events.
+
+    In ClickUp's hierarchy:
+    - Team (workspace) → Workflow Automation
+
+    Attributes:
+        workflow_id: The unique identifier for the workflow (aliased as 'id' for compatibility)
+        team_id: The ID of the team/workspace this workflow belongs to
+        name: Workflow automation name
+        description: Description of the automation
+        trigger_type: Type of trigger (e.g., task_created, status_changed)
+        trigger_config: Configuration for the trigger
+        actions: List of actions to execute
+        is_active: Whether the workflow is active
+        priority: Execution priority
+        date_created: Creation date in epoch milliseconds
+        date_updated: Last update date in epoch milliseconds
+
+    Key Design Features:
+    - Backward-compatible 'id' property that returns workflow_id
+    - Behavior methods that enforce domain invariants
+    - References other aggregates by ID only (no nested objects)
+    - Uses epoch milliseconds for time fields (vendor-agnostic)
+    - Immutable once created (inherited from BaseDomainModel)
+
+    Usage Examples:
+        # Python - Create from API response
+        from clickup_mcp.models.domain.workflow import Workflow
+
+        workflow = Workflow(
+            id="wf_123",
+            team_id="team_001",
+            name="Auto-assign on create",
+            trigger_type="task_created",
+            trigger_config={"list_id": "456"},
+            actions=[{"type": "assign", "user_id": "789"}],
+            is_active=True
+        )
+
+        # Python - Use domain behaviors
+        workflow.activate()
+        workflow.deactivate()
+        workflow.update_name("Updated name")
+    """
+
+    workflow_id: str = Field(alias="id", description="The unique identifier for the workflow")
+    team_id: str = Field(description="Team/workspace ID this workflow belongs to")
+    name: str = Field(description="Workflow automation name")
+    description: str | None = Field(default=None, description="Description of the automation")
+    trigger_type: str = Field(description="Type of trigger (e.g., 'task_created', 'status_changed')")
+    trigger_config: dict = Field(default_factory=dict, description="Configuration for the trigger")
+    actions: List[dict] = Field(default_factory=list, description="List of actions to execute")
+    is_active: bool = Field(default=True, description="Whether the workflow is active")
+    priority: int | None = Field(default=None, description="Execution priority")
+    date_created: int | None = Field(default=None, description="Creation date in epoch milliseconds")
+    date_updated: int | None = Field(default=None, description="Last update date in epoch milliseconds")
+
+    @property
+    def id(self) -> str:
+        """
+        Get the workflow ID for backward compatibility.
+
+        This property provides backward compatibility by allowing access
+        to the workflow ID via the 'id' property, even though the field is
+        named 'workflow_id'.
+
+        Returns:
+            str: The workflow ID (same as workflow_id)
+
+        Usage Examples:
+            # Python - Access via backward-compatible id property
+            workflow = Workflow(id="wf_123", team_id="team_001", name="Auto-assign")
+            print(workflow.id)  # "wf_123"
+            print(workflow.workflow_id)  # "wf_123" (same value)
+        """
+        return self.workflow_id
+
+    # Behaviors / Invariants
+    def update_name(self, name: str) -> None:
+        """
+        Update the workflow name.
+
+        Updates the name to a new value. Validates that the name is not empty.
+
+        Args:
+            name: The new workflow name
+
+        Raises:
+            ValueError: If name is an empty string
+
+        Usage Examples:
+            # Python - Update name
+            workflow = Workflow(id="wf_123", team_id="team_001", name="Auto-assign")
+            workflow.update_name("Updated Workflow Name")
+            print(workflow.name)  # "Updated Workflow Name"
+
+            # Python - Error on empty string
+            try:
+                workflow.update_name("")  # Raises ValueError
+            except ValueError as e:
+                print(f"Error: {e}")
+        """
+        if not name.strip():
+            raise ValueError("name cannot be empty string")
+        self.name = name
+
+    def update_description(self, description: str | None) -> None:
+        """
+        Update the workflow description.
+
+        Updates the description to a new value. Accepts None to clear the description.
+        Validates that non-None description values are not empty strings.
+
+        Args:
+            description: The new description or None to clear
+
+        Raises:
+            ValueError: If description is an empty string
+
+        Usage Examples:
+            # Python - Update description
+            workflow = Workflow(id="wf_123", team_id="team_001", name="Auto-assign")
+            workflow.update_description("Updated description")
+            print(workflow.description)  # "Updated description"
+
+            # Python - Clear description
+            workflow.update_description(None)
+            print(workflow.description)  # None
+        """
+        if description is not None and not description.strip():
+            raise ValueError("description cannot be empty string")
+        self.description = description
+
+    def set_trigger_type(self, trigger_type: str) -> None:
+        """
+        Set the trigger type.
+
+        Updates the trigger type. Validates that the trigger type is one of the valid values.
+
+        Args:
+            trigger_type: The new trigger type (e.g., "task_created", "status_changed")
+
+        Raises:
+            ValueError: If trigger_type is an empty string
+
+        Usage Examples:
+            # Python - Set trigger type
+            workflow = Workflow(id="wf_123", team_id="team_001", name="Auto-assign")
+            workflow.set_trigger_type("status_changed")
+            print(workflow.trigger_type)  # "status_changed"
+        """
+        if not trigger_type.strip():
+            raise ValueError("trigger_type cannot be empty string")
+        self.trigger_type = trigger_type
+
+    def set_trigger_config(self, trigger_config: dict) -> None:
+        """
+        Set the trigger configuration.
+
+        Updates the trigger configuration.
+
+        Args:
+            trigger_config: The new trigger configuration
+
+        Usage Examples:
+            # Python - Set trigger config
+            workflow = Workflow(id="wf_123", team_id="team_001", name="Auto-assign")
+            workflow.set_trigger_config({"list_id": "456"})
+            print(workflow.trigger_config)  # {"list_id": "456"}
+        """
+        self.trigger_config = trigger_config
+
+    def set_actions(self, actions: List[dict]) -> None:
+        """
+        Set the actions to execute.
+
+        Updates the list of actions to execute when the workflow triggers.
+
+        Args:
+            actions: The new list of actions
+
+        Usage Examples:
+            # Python - Set actions
+            workflow = Workflow(id="wf_123", team_id="team_001", name="Auto-assign")
+            workflow.set_actions([{"type": "assign", "user_id": "789"}])
+            print(workflow.actions)  # [{"type": "assign", "user_id": "789"}]
+        """
+        self.actions = actions
+
+    def add_action(self, action: dict) -> None:
+        """
+        Add an action to the workflow.
+
+        Adds a new action to the workflow's actions list.
+
+        Args:
+            action: The action to add
+
+        Raises:
+            ValueError: If action is empty or already exists
+
+        Usage Examples:
+            # Python - Add action
+            workflow = Workflow(id="wf_123", team_id="team_001", name="Auto-assign")
+            workflow.add_action({"type": "assign", "user_id": "789"})
+            print(workflow.actions)  # [{"type": "assign", "user_id": "789"}]
+        """
+        if not action:
+            raise ValueError("action cannot be empty")
+        if action in self.actions:
+            raise ValueError(f"action '{action}' already exists")
+        self.actions.append(action)
+
+    def remove_action(self, action: dict) -> None:
+        """
+        Remove an action from the workflow.
+
+        Removes an action from the workflow's actions list.
+
+        Args:
+            action: The action to remove
+
+        Raises:
+            ValueError: If action is not in the list
+
+        Usage Examples:
+            # Python - Remove action
+            workflow = Workflow(
+                id="wf_123",
+                team_id="team_001",
+                name="Auto-assign",
+                actions=[{"type": "assign", "user_id": "789"}]
+            )
+            workflow.remove_action({"type": "assign", "user_id": "789"})
+            print(workflow.actions)  # []
+        """
+        if action not in self.actions:
+            raise ValueError(f"action '{action}' not found")
+        self.actions.remove(action)
+
+    def activate(self) -> None:
+        """
+        Activate the workflow.
+
+        Sets the workflow to active status, enabling it to execute when triggered.
+
+        Usage Examples:
+            # Python - Activate workflow
+            workflow = Workflow(id="wf_123", team_id="team_001", name="Auto-assign", is_active=False)
+            workflow.activate()
+            print(workflow.is_active)  # True
+        """
+        self.is_active = True
+
+    def deactivate(self) -> None:
+        """
+        Deactivate the workflow.
+
+        Sets the workflow to inactive status, disabling it from executing when triggered.
+
+        Usage Examples:
+            # Python - Deactivate workflow
+            workflow = Workflow(id="wf_123", team_id="team_001", name="Auto-assign", is_active=True)
+            workflow.deactivate()
+            print(workflow.is_active)  # False
+        """
+        self.is_active = False
+
+    def set_priority(self, priority: int) -> None:
+        """
+        Set the execution priority.
+
+        Updates the workflow's execution priority.
+
+        Args:
+            priority: The new priority value
+
+        Raises:
+            ValueError: If priority is negative
+
+        Usage Examples:
+            # Python - Set priority
+            workflow = Workflow(id="wf_123", team_id="team_001", name="Auto-assign")
+            workflow.set_priority(1)
+            print(workflow.priority)  # 1
+        """
+        if priority < 0:
+            raise ValueError("priority must be non-negative")
+        self.priority = priority
+
+    def is_active_workflow(self) -> bool:
+        """
+        Check if the workflow is active.
+
+        Returns:
+            bool: True if the workflow is active
+
+        Usage Examples:
+            # Python - Check if active
+            workflow = Workflow(id="wf_123", team_id="team_001", name="Auto-assign", is_active=True)
+            print(workflow.is_active_workflow())  # True
+
+            workflow.deactivate()
+            print(workflow.is_active_workflow())  # False
+        """
+        return self.is_active


### PR DESCRIPTION
## Description
Add workflow automation input models and domain logic.

This PR implements the foundational workflow automation models including:
- MCP input models for workflow CRUD operations (Create, Get, Update, Delete, List)
- Domain model with business logic for workflow automation
- Export of workflow model in domain module

## Changes
- Created `clickup_mcp/mcp_server/models/inputs/workflow.py` with input models
- Created `clickup_mcp/models/domain/workflow.py` with domain model
- Updated `clickup_mcp/models/domain/__init__.py` to export Workflow

## Testing
- All existing tests pass
- Domain model includes validation and business logic methods

## Related Issues
Linked to Task 5.1, Task 5.2, Task 5.3