### PR TITLE
[MCP-102] ✨ workflow: Add DTOs and mappers

### DIFF
--- a/clickup_mcp/mcp_server/models/inputs/workflow.py
+++ b/clickup_mcp/mcp_server/models/inputs/workflow.py
@@ -4,7 +4,7 @@ These inputs are LLM-friendly contracts used by FastMCP tools. They map to
 Domain entities first, then DTOs for ClickUp wire format.
 """
 
-from typing import List, Literal, Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -55,13 +55,18 @@ class WorkflowCreateInput(BaseModel):
         None, description="Description of the automation.", examples=["Auto-assign tasks when created in list 456"]
     )
     trigger_type: str = Field(
-        ..., min_length=1, description="Type of trigger (e.g., task_created, status_changed).", examples=["task_created", "status_changed"]
+        ...,
+        min_length=1,
+        description="Type of trigger (e.g., task_created, status_changed).",
+        examples=["task_created", "status_changed"],
     )
     trigger_config: Optional[dict] = Field(
         None, description="Configuration for the trigger.", examples=[{"list_id": "456"}, {"status": "done"}]
     )
     actions: List[dict] = Field(
-        default_factory=list, description="List of actions to execute.", examples=[[{"type": "assign", "user_id": "789"}]]
+        default_factory=list,
+        description="List of actions to execute.",
+        examples=[[{"type": "assign", "user_id": "789"}]],
     )
     is_active: bool = Field(True, description="Whether the workflow is active.", examples=[True, False])
     priority: Optional[int] = Field(None, description="Execution priority.", examples=[1, 2, 3])
@@ -96,15 +101,9 @@ class WorkflowUpdateInput(BaseModel):
     )
 
     workflow_id: str = Field(..., min_length=1, description="Workflow automation ID.", examples=["wf_123"])
-    name: Optional[str] = Field(
-        None, min_length=1, description="New workflow name.", examples=["Updated name"]
-    )
-    description: Optional[str] = Field(
-        None, description="New description.", examples=["Updated description"]
-    )
-    trigger_type: Optional[str] = Field(
-        None, description="New trigger type.", examples=["status_changed"]
-    )
+    name: Optional[str] = Field(None, min_length=1, description="New workflow name.", examples=["Updated name"])
+    description: Optional[str] = Field(None, description="New description.", examples=["Updated description"])
+    trigger_type: Optional[str] = Field(None, description="New trigger type.", examples=["status_changed"])
     trigger_config: Optional[dict] = Field(
         None, description="New trigger configuration.", examples=[{"status": "done"}]
     )

--- a/clickup_mcp/models/dto/workflow.py
+++ b/clickup_mcp/models/dto/workflow.py
@@ -1,0 +1,245 @@
+"""
+Workflow DTOs for ClickUp API requests and responses.
+
+These DTOs provide serialization and deserialization helpers for ClickUp Workflow
+operations, including create, update, and list queries. All request DTOs inherit
+from `BaseRequestDTO` and exclude None values from payloads; response DTOs
+inherit from `BaseResponseDTO`.
+
+Usage Examples:
+    # Python - Create workflow payload
+    from clickup_mcp.models.dto.workflow import WorkflowCreate
+
+    payload = WorkflowCreate(
+        name="Auto-assign on create",
+        trigger_type="task_created",
+        trigger_config={"list_id": "456"},
+        actions=[{"type": "assign", "user_id": "789"}]
+    ).to_payload()
+    # => {"name": "Auto-assign on create", "trigger_type": "task_created", ...}
+"""
+
+from typing import Any, Dict, List
+
+from pydantic import Field
+
+from .base import BaseRequestDTO, BaseResponseDTO
+
+
+class WorkflowCreate(BaseRequestDTO):
+    """
+    DTO for creating a new workflow automation.
+
+    API:
+        POST /team/{team_id}/workflow
+
+    Attributes:
+        name: Workflow automation name
+        description: Description of the automation
+        trigger_type: Type of trigger (e.g., task_created, status_changed)
+        trigger_config: Configuration for the trigger
+        actions: List of actions to execute
+        is_active: Whether the workflow is active
+        priority: Execution priority
+
+    Examples:
+        WorkflowCreate(
+            name="Auto-assign on create",
+            trigger_type="task_created",
+            trigger_config={"list_id": "456"},
+            actions=[{"type": "assign", "user_id": "789"}]
+        ).to_payload()
+    """
+
+    name: str = Field(description="Workflow automation name")
+    description: str | None = Field(default=None, description="Description of the automation")
+    trigger_type: str = Field(description="Type of trigger (e.g., 'task_created', 'status_changed')")
+    trigger_config: Dict[str, Any] = Field(default_factory=dict, description="Configuration for the trigger")
+    actions: List[Dict[str, Any]] = Field(default_factory=list, description="List of actions to execute")
+    is_active: bool = Field(default=True, description="Whether the workflow is active")
+    priority: int | None = Field(default=None, description="Execution priority")
+
+    def to_payload(self) -> Dict[str, Any]:
+        """
+        Convert the DTO into a ClickUp create-workflow request body.
+
+        Returns:
+            Dict[str, Any]: JSON-serializable payload with None values removed.
+        """
+        return self.model_dump(exclude_none=True)
+
+
+class WorkflowUpdate(BaseRequestDTO):
+    """
+    DTO for updating a workflow automation.
+
+    API:
+        PUT /workflow/{workflow_id}
+
+    Attributes:
+        name: New workflow name
+        description: New description
+        trigger_type: New trigger type
+        trigger_config: New trigger configuration
+        actions: New list of actions
+        is_active: New active status
+        priority: New priority
+
+    Examples:
+        WorkflowUpdate(name="Updated name", is_active=False).to_payload()
+    """
+
+    name: str | None = Field(default=None, description="New workflow name")
+    description: str | None = Field(default=None, description="New description")
+    trigger_type: str | None = Field(default=None, description="New trigger type")
+    trigger_config: Dict[str, Any] | None = Field(default=None, description="New trigger configuration")
+    actions: List[Dict[str, Any]] | None = Field(default=None, description="New list of actions")
+    is_active: bool | None = Field(default=None, description="New active status")
+    priority: int | None = Field(default=None, description="New priority")
+
+    def to_payload(self) -> Dict[str, Any]:
+        """
+        Convert the DTO into a ClickUp update-workflow request body.
+
+        Returns:
+            Dict[str, Any]: JSON-serializable payload with None values removed.
+        """
+        return self.model_dump(exclude_none=True)
+
+
+class WorkflowListQuery(BaseRequestDTO):
+    """
+    DTO for listing workflow automations with query parameters.
+
+    API:
+        GET /team/{team_id}/workflow
+
+    Attributes:
+        page: Page number (0-indexed)
+        limit: Page size (cap 100)
+        is_active: Filter by active status
+
+    Examples:
+        WorkflowListQuery(limit=50, is_active=True).to_query()
+    """
+
+    page: int = Field(default=0, description="Page number (0-indexed)")
+    limit: int = Field(default=100, description="Page size (cap 100 by API)")
+    is_active: bool | None = Field(default=None, description="Filter by active status")
+
+    def to_query(self) -> Dict[str, str]:
+        """
+        Convert the DTO into ClickUp query parameters.
+
+        Returns:
+            Dict[str, str]: Query parameters as string values.
+        """
+        query: Dict[str, str] = {}
+        if self.page is not None:
+            query["page"] = str(self.page)
+        if self.limit is not None:
+            query["limit"] = str(self.limit)
+        if self.is_active is not None:
+            query["is_active"] = str(self.is_active).lower()
+        return query
+
+
+class WorkflowResponse(BaseResponseDTO):
+    """
+    DTO for workflow automation API responses.
+
+    API:
+        GET /workflow/{workflow_id}
+        POST /team/{team_id}/workflow
+        PUT /workflow/{workflow_id}
+
+    Attributes:
+        id: Workflow automation ID
+        team_id: Team/workspace ID
+        name: Workflow automation name
+        description: Description of the automation
+        trigger_type: Type of trigger
+        trigger_config: Configuration for the trigger
+        actions: List of actions to execute
+        is_active: Whether the workflow is active
+        priority: Execution priority
+        date_created: Creation date in epoch milliseconds
+        date_updated: Last update date in epoch milliseconds
+
+    Examples:
+        WorkflowResponse.deserialize(api_response_data)
+    """
+
+    id: str = Field(description="Workflow automation ID")
+    team_id: str = Field(description="Team/workspace ID")
+    name: str = Field(description="Workflow automation name")
+    description: str | None = Field(default=None, description="Description of the automation")
+    trigger_type: str = Field(description="Type of trigger")
+    trigger_config: Dict[str, Any] = Field(default_factory=dict, description="Configuration for the trigger")
+    actions: List[Dict[str, Any]] = Field(default_factory=list, description="List of actions to execute")
+    is_active: bool = Field(default=True, description="Whether the workflow is active")
+    priority: int | None = Field(default=None, description="Execution priority")
+    date_created: int | None = Field(default=None, description="Creation date in epoch milliseconds")
+    date_updated: int | None = Field(default=None, description="Last update date in epoch milliseconds")
+
+    @classmethod
+    def deserialize(cls, data: Dict[str, Any]) -> "WorkflowResponse":
+        """
+        Deserialize API response data into a WorkflowResponse DTO.
+
+        Args:
+            data: Raw API response data
+
+        Returns:
+            WorkflowResponse: Deserialized DTO instance
+
+        Examples:
+            WorkflowResponse.deserialize({"id": "wf_123", "name": "Auto-assign", ...})
+        """
+        return cls(**data)
+
+
+class WorkflowListResponse(BaseResponseDTO):
+    """
+    DTO for workflow automation list API responses.
+
+    API:
+        GET /team/{team_id}/workflow
+
+    Attributes:
+        items: List of workflow automation responses
+        page: Current page number
+        limit: Page size
+        total: Total number of workflows
+
+    Examples:
+        WorkflowListResponse.deserialize(api_response_data)
+    """
+
+    items: List[WorkflowResponse] = Field(default_factory=list, description="List of workflow automations")
+    page: int = Field(default=0, description="Current page number")
+    limit: int = Field(default=100, description="Page size")
+    total: int | None = Field(default=None, description="Total number of workflows")
+
+    @classmethod
+    def deserialize(cls, data: Dict[str, Any]) -> "WorkflowListResponse":
+        """
+        Deserialize API response data into a WorkflowListResponse DTO.
+
+        Args:
+            data: Raw API response data
+
+        Returns:
+            WorkflowListResponse: Deserialized DTO instance
+
+        Examples:
+            WorkflowListResponse.deserialize({"items": [...], "page": 0, "limit": 100})
+        """
+        items_data = data.get("items", [])
+        items = [WorkflowResponse.deserialize(item) for item in items_data]
+        return cls(
+            items=items,
+            page=data.get("page", 0),
+            limit=data.get("limit", 100),
+            total=data.get("total"),
+        )

--- a/clickup_mcp/models/mapping/workflow_mapper.py
+++ b/clickup_mcp/models/mapping/workflow_mapper.py
@@ -1,0 +1,284 @@
+"""
+Workflow DTO ↔ Domain mappers.
+
+This module implements the Anti-Corruption Layer (ACL) pattern for Workflow resources,
+translating between transport DTOs (Data Transfer Objects) from the ClickUp API
+and the vendor-agnostic Workflow domain entity.
+
+The mapper follows a unidirectional flow:
+1. MCP Input → Domain Entity (from_create_input, from_update_input)
+2. API Response DTO → Domain Entity (to_domain)
+3. Domain Entity → API Request DTO (to_create_dto, to_update_dto)
+4. Domain Entity → MCP Output (to_workflow_result_output, to_workflow_list_item_output)
+
+Special Handling:
+- Trigger config normalization: Converts between different trigger configurations
+- Actions normalization: Handles action list transformations
+- Nested objects: Extracts IDs from nested objects
+
+Usage Examples:
+    # Python - Map MCP input to domain
+    from clickup_mcp.models.mapping.workflow_mapper import WorkflowMapper
+
+    workflow_domain = WorkflowMapper.from_create_input(mcp_input)
+
+    # Python - Map API response to domain
+    workflow_domain = WorkflowMapper.to_domain(api_response_dto)
+
+    # Python - Map domain to API request
+    create_dto = WorkflowMapper.to_create_dto(workflow_domain)
+
+    # Python - Map domain to MCP output
+    mcp_output = WorkflowMapper.to_workflow_result_output(workflow_domain)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from clickup_mcp.models.domain.workflow import Workflow
+from clickup_mcp.models.dto.workflow import (
+    WorkflowCreate,
+    WorkflowListResponse,
+    WorkflowResponse,
+    WorkflowUpdate,
+)
+
+if TYPE_CHECKING:  # type hints only; avoid importing mcp_server package at runtime
+    from clickup_mcp.mcp_server.models.inputs.workflow import (
+        WorkflowCreateInput,
+        WorkflowUpdateInput,
+    )
+    from clickup_mcp.mcp_server.models.outputs.workflow import (
+        WorkflowListItem,
+        WorkflowResult,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class WorkflowMapper:
+    """
+    Static mapper for converting between Workflow DTOs and domain entity.
+
+    This class implements the Anti-Corruption Layer (ACL) pattern, providing
+    unidirectional mappings between different representations of Workflow data:
+
+    1. **MCP Input → Domain**: Converts user-facing MCP input models to domain entities
+    2. **API Response → Domain**: Converts ClickUp API responses to domain entities
+    3. **Domain → API Request**: Converts domain entities to ClickUp API request DTOs
+    4. **Domain → MCP Output**: Converts domain entities to user-facing MCP output models
+
+    Key Design Principles:
+    - **Separation of Concerns**: Domain logic is isolated from transport details
+    - **Unidirectional Flow**: Data flows in one direction through the mapper
+    - **Testability**: Each mapping can be tested independently
+    - **Maintainability**: Changes to DTOs don't affect domain logic
+
+    Attributes:
+        None - This is a static utility class with no instance state
+
+    Usage Examples:
+        # Python - Create a workflow from MCP input
+        from clickup_mcp.models.mapping.workflow_mapper import WorkflowMapper
+        from clickup_mcp.mcp_server.models.inputs.workflow import WorkflowCreateInput
+
+        mcp_input = WorkflowCreateInput(
+            team_id="team_123",
+            name="Auto-assign on create",
+            trigger_type="task_created",
+            trigger_config={"list_id": "456"},
+            actions=[{"type": "assign", "user_id": "789"}]
+        )
+        workflow_domain = WorkflowMapper.from_create_input(mcp_input)
+
+        # Python - Convert API response to domain
+        workflow_domain = WorkflowMapper.to_domain(api_response_dto)
+
+        # Python - Prepare for API request
+        create_dto = WorkflowMapper.to_create_dto(workflow_domain)
+    """
+
+    @staticmethod
+    def from_create_input(mcp_input: "WorkflowCreateInput") -> Workflow:
+        """
+        Convert MCP input model to Workflow domain entity.
+
+        Args:
+            mcp_input: MCP input model from workflow creation request
+
+        Returns:
+            Workflow: Domain entity with business logic
+
+        Examples:
+            WorkflowMapper.from_create_input(
+                WorkflowCreateInput(team_id="team_123", name="Auto-assign", ...)
+            )
+        """
+        return Workflow(
+            id="temp",  # Temporary ID, will be replaced by API response
+            team_id=mcp_input.team_id,
+            name=mcp_input.name,
+            description=mcp_input.description,
+            trigger_type=mcp_input.trigger_type,
+            trigger_config=mcp_input.trigger_config or {},
+            actions=mcp_input.actions,
+            is_active=mcp_input.is_active,
+            priority=mcp_input.priority,
+        )
+
+    @staticmethod
+    def from_update_input(mcp_input: "WorkflowUpdateInput") -> Workflow:
+        """
+        Convert MCP input model to Workflow domain entity for updates.
+
+        Args:
+            mcp_input: MCP input model from workflow update request
+
+        Returns:
+            Workflow: Domain entity with business logic
+
+        Examples:
+            WorkflowMapper.from_update_input(
+                WorkflowUpdateInput(workflow_id="wf_123", name="Updated name", ...)
+            )
+        """
+        return Workflow(
+            id=mcp_input.workflow_id,
+            team_id="temp",  # Not used in update
+            name=mcp_input.name or "",
+            description=mcp_input.description,
+            trigger_type=mcp_input.trigger_type or "",
+            trigger_config=mcp_input.trigger_config or {},
+            actions=mcp_input.actions or [],
+            is_active=mcp_input.is_active if mcp_input.is_active is not None else True,
+            priority=mcp_input.priority,
+        )
+
+    @staticmethod
+    def to_domain(response: WorkflowResponse) -> Workflow:
+        """
+        Convert API response DTO to Workflow domain entity.
+
+        Args:
+            response: API response DTO from ClickUp
+
+        Returns:
+            Workflow: Domain entity with business logic
+
+        Examples:
+            WorkflowMapper.to_domain(WorkflowResponse.deserialize(api_data))
+        """
+        return Workflow(
+            id=response.id,
+            team_id=response.team_id,
+            name=response.name,
+            description=response.description,
+            trigger_type=response.trigger_type,
+            trigger_config=response.trigger_config,
+            actions=response.actions,
+            is_active=response.is_active,
+            priority=response.priority,
+            date_created=response.date_created,
+            date_updated=response.date_updated,
+        )
+
+    @staticmethod
+    def to_create_dto(domain: Workflow) -> WorkflowCreate:
+        """
+        Convert Workflow domain entity to API create request DTO.
+
+        Args:
+            domain: Workflow domain entity
+
+        Returns:
+            WorkflowCreate: API request DTO for creating workflow
+
+        Examples:
+            WorkflowMapper.to_create_dto(workflow_domain)
+        """
+        return WorkflowCreate(
+            name=domain.name,
+            description=domain.description,
+            trigger_type=domain.trigger_type,
+            trigger_config=domain.trigger_config,
+            actions=domain.actions,
+            is_active=domain.is_active,
+            priority=domain.priority,
+        )
+
+    @staticmethod
+    def to_update_dto(domain: Workflow) -> WorkflowUpdate:
+        """
+        Convert Workflow domain entity to API update request DTO.
+
+        Args:
+            domain: Workflow domain entity
+
+        Returns:
+            WorkflowUpdate: API request DTO for updating workflow
+
+        Examples:
+            WorkflowMapper.to_update_dto(workflow_domain)
+        """
+        return WorkflowUpdate(
+            name=domain.name if domain.name else None,
+            description=domain.description,
+            trigger_type=domain.trigger_type if domain.trigger_type else None,
+            trigger_config=domain.trigger_config if domain.trigger_config else None,
+            actions=domain.actions if domain.actions else None,
+            is_active=domain.is_active,
+            priority=domain.priority,
+        )
+
+    @staticmethod
+    def to_workflow_result_output(domain: Workflow) -> dict[str, object]:
+        """
+        Convert Workflow domain entity to MCP result output format.
+
+        Args:
+            domain: Workflow domain entity
+
+        Returns:
+            dict[str, object]: MCP output format for workflow result
+
+        Examples:
+            WorkflowMapper.to_workflow_result_output(workflow_domain)
+        """
+        return {
+            "id": domain.workflow_id,
+            "team_id": domain.team_id,
+            "name": domain.name,
+            "description": domain.description,
+            "trigger_type": domain.trigger_type,
+            "trigger_config": domain.trigger_config,
+            "actions": domain.actions,
+            "is_active": domain.is_active,
+            "priority": domain.priority,
+            "date_created": domain.date_created,
+            "date_updated": domain.date_updated,
+        }
+
+    @staticmethod
+    def to_workflow_list_item_output(domain: Workflow) -> dict[str, object]:
+        """
+        Convert Workflow domain entity to MCP list item output format.
+
+        Args:
+            domain: Workflow domain entity
+
+        Returns:
+            dict[str, object]: MCP output format for workflow list item
+
+        Examples:
+            WorkflowMapper.to_workflow_list_item_output(workflow_domain)
+        """
+        return {
+            "id": domain.workflow_id,
+            "team_id": domain.team_id,
+            "name": domain.name,
+            "trigger_type": domain.trigger_type,
+            "is_active": domain.is_active,
+            "priority": domain.priority,
+        }

--- a/clickup_mcp/models/mapping/workflow_mapper.py
+++ b/clickup_mcp/models/mapping/workflow_mapper.py
@@ -40,7 +40,6 @@ from typing import TYPE_CHECKING
 from clickup_mcp.models.domain.workflow import Workflow
 from clickup_mcp.models.dto.workflow import (
     WorkflowCreate,
-    WorkflowListResponse,
     WorkflowResponse,
     WorkflowUpdate,
 )
@@ -49,10 +48,6 @@ if TYPE_CHECKING:  # type hints only; avoid importing mcp_server package at runt
     from clickup_mcp.mcp_server.models.inputs.workflow import (
         WorkflowCreateInput,
         WorkflowUpdateInput,
-    )
-    from clickup_mcp.mcp_server.models.outputs.workflow import (
-        WorkflowListItem,
-        WorkflowResult,
     )
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Description
Create workflow DTOs and mappers.

This PR implements the data transfer objects and mapper for workflow automation:
- Workflow DTOs for create, update, list operations
- Workflow mapper for DTO ↔ Domain conversion following ACL pattern

## Changes
- Created `clickup_mcp/models/dto/workflow.py` with DTOs
- Created `clickup_mcp/models/mapping/workflow_mapper.py` with mapper

## Testing
- DTOs follow existing patterns from task/goal DTOs
- Mapper implements Anti-Corruption Layer pattern

## Related Issues
Linked to Task 5.3