### PR TITLE
[MCP-130] ✅ task: Add assignment tests

### DIFF
--- a/clickup_mcp/api/task.py
+++ b/clickup_mcp/api/task.py
@@ -478,7 +478,7 @@ class TaskAPI:
               https://api.clickup.com/api/v2/task/abc123/member/42
         """
         response = await self._client.post(f"/task/{task_id}/member/{assignee_id}")
-        return response.success and response.status_code in (200, 201)
+        return response.success and response.status_code in (200, 201, 204)
 
     async def remove_assignee(self, task_id: ClickUpTaskID, assignee_id: int | str) -> bool:
         """

--- a/test/unit_test/api/test_task.py
+++ b/test/unit_test/api/test_task.py
@@ -337,3 +337,95 @@ class TestTaskAPI(BaseAPIClientTestSuite):
 
         # Assert
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_add_assignee(self, task_api, mock_api_client):
+        """Test adding an assignee to a task."""
+        # Arrange
+        task_id = "task_123"
+        assignee_id = 42
+        mock_api_client.post.return_value = APIResponse(success=True, status_code=204, data=None, headers={})
+
+        # Act
+        result = await task_api.add_assignee(task_id, assignee_id)
+
+        # Assert
+        mock_api_client.post.assert_called_once_with(f"/task/{task_id}/member/{assignee_id}")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_add_assignee_with_string_id(self, task_api, mock_api_client):
+        """Test adding an assignee with string user ID."""
+        # Arrange
+        task_id = "task_123"
+        assignee_id = "user_abc"
+        mock_api_client.post.return_value = APIResponse(success=True, status_code=204, data=None, headers={})
+
+        # Act
+        result = await task_api.add_assignee(task_id, assignee_id)
+
+        # Assert
+        mock_api_client.post.assert_called_once_with(f"/task/{task_id}/member/{assignee_id}")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_add_assignee_returns_false_on_failure(self, task_api, mock_api_client):
+        """Test adding an assignee that fails returns False."""
+        # Arrange
+        task_id = "task_123"
+        assignee_id = 42
+        mock_api_client.post.return_value = APIResponse(
+            success=False, status_code=404, data={"err": "Task not found"}, headers={}
+        )
+
+        # Act
+        result = await task_api.add_assignee(task_id, assignee_id)
+
+        # Assert
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_remove_assignee(self, task_api, mock_api_client):
+        """Test removing an assignee from a task."""
+        # Arrange
+        task_id = "task_123"
+        assignee_id = 42
+        mock_api_client.delete.return_value = APIResponse(success=True, status_code=204, data=None, headers={})
+
+        # Act
+        result = await task_api.remove_assignee(task_id, assignee_id)
+
+        # Assert
+        mock_api_client.delete.assert_called_once_with(f"/task/{task_id}/member/{assignee_id}")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_remove_assignee_with_string_id(self, task_api, mock_api_client):
+        """Test removing an assignee with string user ID."""
+        # Arrange
+        task_id = "task_123"
+        assignee_id = "user_abc"
+        mock_api_client.delete.return_value = APIResponse(success=True, status_code=204, data=None, headers={})
+
+        # Act
+        result = await task_api.remove_assignee(task_id, assignee_id)
+
+        # Assert
+        mock_api_client.delete.assert_called_once_with(f"/task/{task_id}/member/{assignee_id}")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_remove_assignee_returns_false_on_failure(self, task_api, mock_api_client):
+        """Test removing an assignee that fails returns False."""
+        # Arrange
+        task_id = "task_123"
+        assignee_id = 42
+        mock_api_client.delete.return_value = APIResponse(
+            success=False, status_code=404, data={"err": "Task not found"}, headers={}
+        )
+
+        # Act
+        result = await task_api.remove_assignee(task_id, assignee_id)
+
+        # Assert
+        assert result is False

--- a/test/unit_test/mcp_server/test_workspace.py
+++ b/test/unit_test/mcp_server/test_workspace.py
@@ -318,9 +318,7 @@ async def test_workspace_create_with_special_characters(mock_get_client: MagicMo
     """Test creating a workspace with special characters in name."""
     # Test data
     workspace_id: str = "9018752317"
-    mock_workspace_resp: WorkspaceResp = WorkspaceResp(
-        id=workspace_id, name="Team @#$%^&*()", color="#3498db"
-    )
+    mock_workspace_resp: WorkspaceResp = WorkspaceResp(id=workspace_id, name="Team @#$%^&*()", color="#3498db")
 
     # Set up mocks
     mock_client: MagicMock = MagicMock()
@@ -344,9 +342,7 @@ async def test_workspace_create_with_long_name(mock_get_client: MagicMock) -> No
     # Test data
     workspace_id: str = "9018752317"
     long_name = "A" * 200
-    mock_workspace_resp: WorkspaceResp = WorkspaceResp(
-        id=workspace_id, name=long_name, color="#3498db"
-    )
+    mock_workspace_resp: WorkspaceResp = WorkspaceResp(id=workspace_id, name=long_name, color="#3498db")
 
     # Set up mocks
     mock_client: MagicMock = MagicMock()
@@ -370,9 +366,7 @@ async def test_workspace_create_with_invalid_color_format(mock_get_client: Magic
     # Test data
     workspace_id: str = "9018752317"
     invalid_color = "not-a-valid-color"
-    mock_workspace_resp: WorkspaceResp = WorkspaceResp(
-        id=workspace_id, name="Engineering Team", color=invalid_color
-    )
+    mock_workspace_resp: WorkspaceResp = WorkspaceResp(id=workspace_id, name="Engineering Team", color=invalid_color)
 
     # Set up mocks
     mock_client: MagicMock = MagicMock()


### PR DESCRIPTION
## Linked Task
Task 7.2

## Description
Add comprehensive task assignment tests to ensure the add_assignee and remove_assignee methods are properly tested.

## Changes
- Add test for adding assignee to task with integer ID
- Add test for adding assignee with string ID
- Add test for add assignee failure case
- Add test for removing assignee from task with integer ID
- Add test for removing assignee with string ID
- Add test for remove assignee failure case
- Merged feature/workspace-tests-final branch to resolve conflicts
- Resolved merge conflicts in test_workspace.py by keeping validation fixes (100 character limit and valid hex color format)
- Fixed add_assignee method to accept 204 status code (No Content) in addition to 200 and 201

## Testing
All 23 task API tests now passing. Tests use proper mocking and follow the existing test patterns for TaskAPI.