### PR TITLE
[MCP-131] ✅ task: Add search tests

### DIFF
--- a/test/unit_test/api/test_task.py
+++ b/test/unit_test/api/test_task.py
@@ -435,9 +435,7 @@ class TestTaskAPI(BaseAPIClientTestSuite):
         """Test searching tasks with query parameters."""
         # Arrange
         query = {"team_id": "team_123", "query": "urgent bugs"}
-        mock_api_client.get.return_value = APIResponse(
-            success=True, status_code=200, data=sample_task_data, headers={}
-        )
+        mock_api_client.get.return_value = APIResponse(success=True, status_code=200, data=sample_task_data, headers={})
 
         # Act
         result = await task_api.search(query)
@@ -459,9 +457,7 @@ class TestTaskAPI(BaseAPIClientTestSuite):
             "priorities": [1, 2],
             "statuses": ["open", "in progress"],
         }
-        mock_api_client.get.return_value = APIResponse(
-            success=True, status_code=200, data=sample_task_data, headers={}
-        )
+        mock_api_client.get.return_value = APIResponse(success=True, status_code=200, data=sample_task_data, headers={})
 
         # Act
         result = await task_api.search(query)
@@ -502,9 +498,7 @@ class TestTaskAPI(BaseAPIClientTestSuite):
         """Test searching with empty data returns None."""
         # Arrange
         query = {"team_id": "team_123", "query": "urgent bugs"}
-        mock_api_client.get.return_value = APIResponse(
-            success=True, status_code=200, data=None, headers={}
-        )
+        mock_api_client.get.return_value = APIResponse(success=True, status_code=200, data=None, headers={})
 
         # Act
         result = await task_api.search(query)

--- a/test/unit_test/api/test_task.py
+++ b/test/unit_test/api/test_task.py
@@ -429,3 +429,85 @@ class TestTaskAPI(BaseAPIClientTestSuite):
 
         # Assert
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_search(self, task_api, mock_api_client, sample_task_data):
+        """Test searching tasks with query parameters."""
+        # Arrange
+        query = {"team_id": "team_123", "query": "urgent bugs"}
+        mock_api_client.get.return_value = APIResponse(
+            success=True, status_code=200, data=sample_task_data, headers={}
+        )
+
+        # Act
+        result = await task_api.search(query)
+
+        # Assert
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == "/team/team_123/task"
+        assert call_args[1]["params"] == query
+        assert isinstance(result, TaskResp)
+
+    @pytest.mark.asyncio
+    async def test_search_with_filters(self, task_api, mock_api_client, sample_task_data):
+        """Test searching tasks with multiple filters."""
+        # Arrange
+        query = {
+            "team_id": "team_123",
+            "query": "urgent bugs",
+            "priorities": [1, 2],
+            "statuses": ["open", "in progress"],
+        }
+        mock_api_client.get.return_value = APIResponse(
+            success=True, status_code=200, data=sample_task_data, headers={}
+        )
+
+        # Act
+        result = await task_api.search(query)
+
+        # Assert
+        call_args = mock_api_client.get.call_args
+        assert call_args[1]["params"]["priorities"] == [1, 2]
+        assert call_args[1]["params"]["statuses"] == ["open", "in progress"]
+        assert isinstance(result, TaskResp)
+
+    @pytest.mark.asyncio
+    async def test_search_without_team_id_raises(self, task_api, mock_api_client):
+        """Test searching without team_id raises ValueError."""
+        # Arrange
+        query = {"query": "urgent bugs"}
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="team_id is required for search"):
+            await task_api.search(query)
+
+    @pytest.mark.asyncio
+    async def test_search_returns_none_on_failure(self, task_api, mock_api_client):
+        """Test searching that fails returns None."""
+        # Arrange
+        query = {"team_id": "team_123", "query": "urgent bugs"}
+        mock_api_client.get.return_value = APIResponse(
+            success=False, status_code=404, data={"err": "Team not found"}, headers={}
+        )
+
+        # Act
+        result = await task_api.search(query)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_search_with_empty_data_returns_none(self, task_api, mock_api_client):
+        """Test searching with empty data returns None."""
+        # Arrange
+        query = {"team_id": "team_123", "query": "urgent bugs"}
+        mock_api_client.get.return_value = APIResponse(
+            success=True, status_code=200, data=None, headers={}
+        )
+
+        # Act
+        result = await task_api.search(query)
+
+        # Assert
+        assert result is None

--- a/test/unit_test/mcp_server/test_workspace.py
+++ b/test/unit_test/mcp_server/test_workspace.py
@@ -318,9 +318,7 @@ async def test_workspace_create_with_special_characters(mock_get_client: MagicMo
     """Test creating a workspace with special characters in name."""
     # Test data
     workspace_id: str = "9018752317"
-    mock_workspace_resp: WorkspaceResp = WorkspaceResp(
-        id=workspace_id, name="Team @#$%^&*()", color="#3498db"
-    )
+    mock_workspace_resp: WorkspaceResp = WorkspaceResp(id=workspace_id, name="Team @#$%^&*()", color="#3498db")
 
     # Set up mocks
     mock_client: MagicMock = MagicMock()
@@ -344,9 +342,7 @@ async def test_workspace_create_with_long_name(mock_get_client: MagicMock) -> No
     # Test data
     workspace_id: str = "9018752317"
     long_name = "A" * 200
-    mock_workspace_resp: WorkspaceResp = WorkspaceResp(
-        id=workspace_id, name=long_name, color="#3498db"
-    )
+    mock_workspace_resp: WorkspaceResp = WorkspaceResp(id=workspace_id, name=long_name, color="#3498db")
 
     # Set up mocks
     mock_client: MagicMock = MagicMock()
@@ -370,9 +366,7 @@ async def test_workspace_create_with_invalid_color_format(mock_get_client: Magic
     # Test data
     workspace_id: str = "9018752317"
     invalid_color = "not-a-valid-color"
-    mock_workspace_resp: WorkspaceResp = WorkspaceResp(
-        id=workspace_id, name="Engineering Team", color=invalid_color
-    )
+    mock_workspace_resp: WorkspaceResp = WorkspaceResp(id=workspace_id, name="Engineering Team", color=invalid_color)
 
     # Set up mocks
     mock_client: MagicMock = MagicMock()


### PR DESCRIPTION
## Linked Task
Task 7.3

## Description
Add comprehensive task search tests to ensure the search method is properly tested with various query parameters and edge cases.

## Changes
- Add test for searching tasks with query parameters
- Add test for searching with multiple filters (priorities, statuses)
- Add test for search without team_id validation
- Add test for search failure case
- Add test for search with empty data

## Testing
All new tests use proper mocking and follow the existing test patterns for TaskAPI.