### PR TITLE
[MCP-137] ✅ docs: Add user journey examples

### DIFF
--- a/docs/contents/document/api-references/mcp-server/tools/bottleneck.mdx
+++ b/docs/contents/document/api-references/mcp-server/tools/bottleneck.mdx
@@ -1,0 +1,63 @@
+---
+id: bottleneck-mcp-api
+title: Bottleneck
+sidebar_position: 11
+---
+
+# Bottleneck MCP API
+
+Tools for detecting bottlenecks in team workflows using ClickUp analytics.
+
+:::note Errors and retries
+All MCP tools return a uniform ToolResponse envelope (`ok`, `result`, `issues[]`). When `ok: false`, inspect `issues` 
+and apply retries/backoff (respect `retry_after_ms` for 429 and back off on 5xx/transient errors). See 
+[Errors and Retries (MCP)](../errors-and-retries.mdx) for details.
+:::
+
+## Tools
+
+### bottleneck.detect
+
+Detects bottlenecks in team workflows with date range and optional filters. Read-only.
+- **Parameters**: [BottleneckDetectionInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/bottleneck.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "start_date": 1640995200000, // Start date in epoch ms
+  "end_date": 1643673600000, // End date in epoch ms
+  "list_id": "list_123", // Optional: filter by list
+  "threshold": 5, // Optional: threshold for bottleneck detection
+  "bottleneck_type": "status" // Optional: bottleneck type filter
+}
+```
+
+- **Returns**: [BottleneckDetectionResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/bottleneck.py) in `ToolResponse`
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "id": "bn_123", // Bottleneck detection ID
+    "team_id": "team_1", // Team/workspace ID
+    "list_id": "list_123", // List ID (if filtered)
+    "start_date": 1640995200000, // Start date epoch ms
+    "end_date": 1643673600000, // End date epoch ms
+    "bottleneck_type": "status", // Type of bottleneck
+    "severity": "high", // Severity level
+    "affected_tasks": 25, // Number of affected tasks
+    "threshold": 5, // Threshold used for detection
+    "current_value": 12, // Current value
+    "recommendations": ["Increase assignee capacity"], // Recommendations
+    "date_detected": 1640995200000, // Detection date epoch ms
+    "date_resolved": null // Resolution date epoch ms (null if unresolved)
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `VALIDATION_ERROR` when date range is invalid
+  - `NOT_FOUND` (404) when team_id is invalid
+  - `RATE_LIMIT` (429)

--- a/docs/contents/document/api-references/mcp-server/tools/goal.mdx
+++ b/docs/contents/document/api-references/mcp-server/tools/goal.mdx
@@ -1,0 +1,207 @@
+---
+id: goal-mcp-api
+title: Goal
+sidebar_position: 8
+---
+
+# Goal MCP API
+
+Tools for managing ClickUp goals, including creating, retrieving, listing, updating, and deleting goals with key results.
+
+:::note Errors and retries
+All MCP tools return a uniform ToolResponse envelope (`ok`, `result`, `issues[]`). When `ok: false`, inspect `issues` 
+and apply retries/backoff (respect `retry_after_ms` for 429 and back off on 5xx/transient errors). See 
+[Errors and Retries (MCP)](../errors-and-retries.mdx) for details.
+:::
+
+## Tools
+
+### goal.create
+
+Creates a new goal for a team with name, description, and due date. Time fields are epoch milliseconds. This operation modifies ClickUp data and returns the created goal.
+- **Parameters**: [GoalCreateInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/goal.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "name": "Q1 Revenue Goal", // Goal name
+  "description": "Achieve $1M in revenue", // Optional description
+  "due_date": 1702080000000, // Due date in epoch ms
+  "key_results": ["KR1", "KR2"], // Optional list of key results
+  "owners": [789], // Optional list of owner user IDs
+  "multiple_owners": false, // Optional: allow multiple owners
+  "color": "#FF0000" // Optional: goal color hex code
+}
+```
+
+- **Returns**: [GoalResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/goal.py) in `ToolResponse`
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "id": "goal_123", // Goal ID
+    "team_id": "team_1", // Team/workspace ID
+    "name": "Q1 Revenue Goal", // Goal name
+    "description": "Achieve $1M in revenue", // Description
+    "due_date": 1702080000000, // Due date epoch ms
+    "status": "active", // Goal status
+    "key_results": ["KR1", "KR2"], // Key results
+    "owners": [789], // Owner user IDs
+    "multiple_owners": false, // Multiple owners flag
+    "color": "#FF0000" // Goal color
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `VALIDATION_ERROR` when required fields are missing
+  - `NOT_FOUND` (404) when team_id is invalid
+  - `RATE_LIMIT` (429)
+  - `UPSTREAM_ERROR` (5xx/timeout)
+
+### goal.get
+
+Retrieves a single goal by ID. Read-only.
+- **Parameters**: [GoalGetInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/goal.py)
+
+```jsonc
+{
+  "goal_id": "goal_123" // Goal ID
+}
+```
+
+- **Returns**: [GoalResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/goal.py)
+
+```jsonc
+{
+  "id": "goal_123",
+  "team_id": "team_1",
+  "name": "Q1 Revenue Goal",
+  "description": "Achieve $1M in revenue",
+  "due_date": 1702080000000,
+  "status": "active",
+  "key_results": ["KR1", "KR2"],
+  "owners": [789],
+  "multiple_owners": false
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when goal does not exist
+  - `RATE_LIMIT` (429)
+
+### goal.list
+
+Lists goals for a team with optional filtering by status, owner, and date range. Read-only.
+- **Parameters**: [GoalListInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/goal.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "status": "active", // Optional: filter by status
+  "owner": 789, // Optional: filter by owner user ID
+  "start_date": 1702080000000, // Optional: start date epoch ms
+  "end_date": 1702083600000, // Optional: end date epoch ms
+  "page": 0, // Optional: page number (default 0)
+  "limit": 100 // Optional: page size (default 100)
+}
+```
+
+- **Returns**: [GoalListResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/goal.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "items": [
+      {
+        "id": "goal_123",
+        "team_id": "team_1",
+        "name": "Q1 Revenue Goal",
+        "status": "active"
+      }
+    ],
+    "page": 0,
+    "limit": 100,
+    "total": 25
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `VALIDATION_ERROR` when date range is invalid
+  - `RATE_LIMIT` (429)
+
+### goal.update
+
+Updates an existing goal. This operation modifies ClickUp data.
+- **Parameters**: [GoalUpdateInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/goal.py)
+
+```jsonc
+{
+  "goal_id": "goal_123", // Goal ID
+  "name": "Updated Goal Name", // Optional new name
+  "description": "Updated description", // Optional new description
+  "due_date": 1702083600000, // Optional new due date
+  "status": "completed", // Optional new status
+  "key_results": ["KR1", "KR2", "KR3"], // Optional updated key results
+  "owners": [789, 790], // Optional updated owners
+  "is_active": false // Optional: active flag
+}
+```
+
+- **Returns**: [GoalResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/goal.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "id": "goal_123",
+    "name": "Updated Goal Name",
+    "description": "Updated description",
+    "status": "completed"
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when goal does not exist
+  - `VALIDATION_ERROR` when update data is invalid
+  - `RATE_LIMIT` (429)
+
+### goal.delete
+
+Deletes a goal by ID. This operation permanently removes data from ClickUp.
+- **Parameters**: [GoalDeleteInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/goal.py)
+
+```jsonc
+{
+  "goal_id": "goal_123" // Goal ID to delete
+}
+```
+
+- **Returns**: [DeletionResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/common.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "deleted": true,
+    "id": "goal_123"
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when goal does not exist
+  - `RATE_LIMIT` (429)

--- a/docs/contents/document/api-references/mcp-server/tools/insights.mdx
+++ b/docs/contents/document/api-references/mcp-server/tools/insights.mdx
@@ -1,0 +1,62 @@
+---
+id: insights-mcp-api
+title: Insights
+sidebar_position: 12
+---
+
+# Insights MCP API
+
+Tools for generating insights from ClickUp analytics data.
+
+:::note Errors and retries
+All MCP tools return a uniform ToolResponse envelope (`ok`, `result`, `issues[]`). When `ok: false`, inspect `issues` 
+and apply retries/backoff (respect `retry_after_ms` for 429 and back off on 5xx/transient errors). See 
+[Errors and Retries (MCP)](../errors-and-retries.mdx) for details.
+:::
+
+## Tools
+
+### insights.generate
+
+Generates insights from analytics data with date range and insight type. Read-only.
+- **Parameters**: [InsightsGenerationInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/insights.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "start_date": 1640995200000, // Start date in epoch ms
+  "end_date": 1643673600000, // End date in epoch ms
+  "insight_type": "productivity" // Type of insight (e.g., productivity, efficiency, workload)
+}
+```
+
+- **Returns**: [InsightsGenerationResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/insights.py) in `ToolResponse`
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "id": "ins_123", // Insight ID
+    "team_id": "team_1", // Team/workspace ID
+    "start_date": 1640995200000, // Start date epoch ms
+    "end_date": 1643673600000, // End date epoch ms
+    "insight_type": "productivity", // Type of insight
+    "priority": "high", // Priority level
+    "recommendations": ["Increase task completion rate"], // Recommendations
+    "metrics": {
+      "completion_rate": 85,
+      "average_time": 3600000,
+      "efficiency_score": 75
+    }, // Key metrics
+    "confidence_score": 0.92, // Confidence score (0-1)
+    "date_generated": 1640995200000 // Generation date epoch ms
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `VALIDATION_ERROR` when date range is invalid
+  - `NOT_FOUND` (404) when team_id is invalid
+  - `RATE_LIMIT` (429)

--- a/docs/contents/document/api-references/mcp-server/tools/key_result.mdx
+++ b/docs/contents/document/api-references/mcp-server/tools/key_result.mdx
@@ -1,0 +1,208 @@
+---
+id: key-result-mcp-api
+title: Key Result
+sidebar_position: 10
+---
+
+# Key Result MCP API
+
+Tools for managing ClickUp key results, including creating, retrieving, listing, updating, and deleting key results for goals.
+
+:::note Errors and retries
+All MCP tools return a uniform ToolResponse envelope (`ok`, `result`, `issues[]`). When `ok: false`, inspect `issues` 
+and apply retries/backoff (respect `retry_after_ms` for 429 and back off on 5xx/transient errors). See 
+[Errors and Retries (MCP)](../errors-and-retries.mdx) for details.
+:::
+
+## Tools
+
+### key_result.create
+
+Creates a new key result for a goal with name, type, target, and optional unit. Time fields are epoch milliseconds. This operation modifies ClickUp data and returns the created key result.
+- **Parameters**: [KeyResultCreateInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/key_result.py)
+
+```jsonc
+{
+  "goal_id": "goal_123", // Goal ID to create key result for
+  "name": "Increase MRR", // Key result name
+  "type": "currency", // Key result type (e.g., currency, number, boolean)
+  "target": 1000000, // Target value
+  "unit": "$", // Optional unit (e.g., $, %, hours)
+  "description": "Increase monthly recurring revenue", // Optional description
+  "start_value": 500000, // Optional start value
+  "current_value": 750000 // Optional current value
+}
+```
+
+- **Returns**: [KeyResultResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/key_result.py) in `ToolResponse`
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "id": "kr_123", // Key result ID
+    "goal_id": "goal_123", // Parent goal ID
+    "name": "Increase MRR", // Key result name
+    "type": "currency", // Key result type
+    "target": 1000000, // Target value
+    "unit": "$", // Unit
+    "description": "Increase monthly recurring revenue", // Description
+    "start_value": 500000, // Start value
+    "current_value": 750000, // Current value
+    "progress": 50, // Progress percentage
+    "status": "on_track" // Status
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `VALIDATION_ERROR` when required fields are missing
+  - `NOT_FOUND` (404) when goal_id is invalid
+  - `RATE_LIMIT` (429)
+  - `UPSTREAM_ERROR` (5xx/timeout)
+
+### key_result.get
+
+Retrieves a single key result by ID. Read-only.
+- **Parameters**: [KeyResultGetInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/key_result.py)
+
+```jsonc
+{
+  "key_result_id": "kr_123" // Key result ID
+}
+```
+
+- **Returns**: [KeyResultResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/key_result.py)
+
+```jsonc
+{
+  "id": "kr_123",
+  "goal_id": "goal_123",
+  "name": "Increase MRR",
+  "type": "currency",
+  "target": 1000000,
+  "unit": "$",
+  "current_value": 750000,
+  "progress": 75,
+  "status": "on_track"
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when key result does not exist
+  - `RATE_LIMIT` (429)
+
+### key_result.list
+
+Lists key results for a goal. Read-only.
+- **Parameters**: [KeyResultListInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/key_result.py)
+
+```jsonc
+{
+  "goal_id": "goal_123", // Goal ID
+  "page": 0, // Optional: page number (default 0)
+  "limit": 100 // Optional: page size (default 100)
+}
+```
+
+- **Returns**: [KeyResultListResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/key_result.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "items": [
+      {
+        "id": "kr_123",
+        "goal_id": "goal_123",
+        "name": "Increase MRR",
+        "type": "currency",
+        "target": 1000000,
+        "current_value": 750000
+      }
+    ],
+    "page": 0,
+    "limit": 100,
+    "total": 5
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when goal_id is invalid
+  - `RATE_LIMIT` (429)
+
+### key_result.update
+
+Updates an existing key result. This operation modifies ClickUp data.
+- **Parameters**: [KeyResultUpdateInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/key_result.py)
+
+```jsonc
+{
+  "key_result_id": "kr_123", // Key result ID
+  "name": "Updated name", // Optional new name
+  "type": "number", // Optional new type
+  "target": 2000000, // Optional new target
+  "unit": "%", // Optional new unit
+  "current_value": 1500000, // Optional new current value
+  "description": "Updated description", // Optional new description
+  "status": "ahead" // Optional new status
+}
+```
+
+- **Returns**: [KeyResultResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/key_result.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "id": "kr_123",
+    "name": "Updated name",
+    "type": "number",
+    "target": 2000000,
+    "current_value": 1500000,
+    "status": "ahead"
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when key result does not exist
+  - `VALIDATION_ERROR` when update data is invalid
+  - `RATE_LIMIT` (429)
+
+### key_result.delete
+
+Deletes a key result by ID. This operation permanently removes data from ClickUp.
+- **Parameters**: [KeyResultDeleteInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/key_result.py)
+
+```jsonc
+{
+  "key_result_id": "kr_123" // Key result ID to delete
+}
+```
+
+- **Returns**: [DeletionResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/common.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "deleted": true,
+    "id": "kr_123"
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when key result does not exist
+  - `RATE_LIMIT` (429)

--- a/docs/contents/document/api-references/mcp-server/tools/reporting.mdx
+++ b/docs/contents/document/api-references/mcp-server/tools/reporting.mdx
@@ -1,0 +1,108 @@
+---
+id: reporting-mcp-api
+title: Reporting
+sidebar_position: 13
+---
+
+# Reporting MCP API
+
+Tools for creating and listing time reports for teams with date range and assignee filters.
+
+:::note Errors and retries
+All MCP tools return a uniform ToolResponse envelope (`ok`, `result`, `issues[]`). When `ok: false`, inspect `issues` 
+and apply retries/backoff (respect `retry_after_ms` for 429 and back off on 5xx/transient errors). See 
+[Errors and Retries (MCP)](../errors-and-retries.mdx) for details.
+:::
+
+## Tools
+
+### report.create
+
+Creates a time report for a team with date range filters. Time fields are epoch milliseconds. This operation returns time entries matching the report criteria.
+- **Parameters**: [TimeReportCreateInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/reporting.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "start_date": 1702080000000, // Start date in epoch ms
+  "end_date": 1702166400000, // End date in epoch ms
+  "assignee": 789, // Optional: filter by assignee user ID
+  "task_id": "task_123" // Optional: filter by task ID
+}
+```
+
+- **Returns**: [TimeReportListResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/reporting.py) in `ToolResponse`
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "items": [
+      {
+        "id": "entry_123", // Time entry ID
+        "task_id": "task_123", // Associated task
+        "user_id": 789, // User who logged the time
+        "team_id": "team_1", // Team/workspace
+        "duration": 3600000, // Duration in ms
+        "start": 1702080000000, // Start time epoch ms
+        "end": 1702083600000 // End time epoch ms
+      }
+    ],
+    "next_cursor": "cursor=2", // Cursor for pagination
+    "truncated": false // Whether results are truncated
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `VALIDATION_ERROR` when date range is invalid
+  - `NOT_FOUND` (404) when team_id is invalid
+  - `RATE_LIMIT` (429)
+  - `UPSTREAM_ERROR` (5xx/timeout)
+
+### report.list
+
+Lists time entries for a team with filters. Constraints: `limit` ≤ 100. Read-only.
+- **Parameters**: [TimeReportListInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/reporting.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "assignee": 789, // Optional: filter by assignee user ID
+  "task_id": "task_123", // Optional: filter by task ID
+  "start_date": 1702080000000, // Optional: start date epoch ms
+  "end_date": 1702166400000, // Optional: end date epoch ms
+  "page": 0, // Optional: page number (default 0)
+  "limit": 100 // Optional: page size (default 100, max 100)
+}
+```
+
+- **Returns**: [TimeReportListResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/reporting.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "items": [
+      {
+        "id": "entry_123",
+        "task_id": "task_123",
+        "user_id": 789,
+        "duration": 3600000,
+        "start": 1702080000000
+      }
+    ],
+    "next_cursor": "cursor=2",
+    "truncated": false
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `VALIDATION_ERROR` when limit > 100 or date range is invalid
+  - `NOT_FOUND` (404) when team_id is invalid
+  - `RATE_LIMIT` (429)

--- a/docs/contents/document/api-references/mcp-server/tools/time.mdx
+++ b/docs/contents/document/api-references/mcp-server/tools/time.mdx
@@ -1,0 +1,293 @@
+---
+id: time-mcp-api
+title: Time
+sidebar_position: 7
+---
+
+# Time MCP API
+
+Tools for managing time entries and time tracking in ClickUp, including creating, retrieving, listing, updating, and deleting time entries, as well as starting, stopping, and checking the status of time tracking.
+
+:::note Errors and retries
+All MCP tools return a uniform ToolResponse envelope (`ok`, `result`, `issues[]`). When `ok: false`, inspect `issues` 
+and apply retries/backoff (respect `retry_after_ms` for 429 and back off on 5xx/transient errors). See 
+[Errors and Retries (MCP)](../errors-and-retries.mdx) for details.
+:::
+
+## Tools
+
+### time_entry.create
+
+Creates a new time entry for a task. Requires either `duration` or both `start` and `end` times. Time fields are epoch milliseconds. This operation modifies ClickUp data and returns the created time entry.
+- **Parameters**: [TimeEntryCreateInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/time.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "task_id": "task_123", // Task ID to log time against
+  "description": "Work on feature", // Optional description
+  "start": 1731523200000, // Optional start time in epoch ms
+  "end": 1731526800000, // Optional end time in epoch ms
+  "duration": 3600000 // Optional duration in ms (use if no start/end)
+}
+```
+
+- **Returns**: [TimeEntryResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/time.py) in `ToolResponse`
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "id": "entry_123", // Time entry ID
+    "task_id": "task_123", // Associated task
+    "user_id": 789, // User who logged the time
+    "team_id": "team_1", // Team/workspace
+    "description": "Work on feature", // Description
+    "duration": 3600000, // Duration in ms
+    "start": 1731523200000, // Start time epoch ms
+    "end": 1731526800000 // End time epoch ms
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `VALIDATION_ERROR` when duration or start/end are invalid
+  - `NOT_FOUND` (404) when task_id is invalid
+  - `RATE_LIMIT` (429)
+  - `UPSTREAM_ERROR` (5xx/timeout)
+
+### time_entry.get
+
+Retrieves a single time entry by ID. Read-only.
+- **Parameters**: [TimeEntryGetInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/time.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "time_entry_id": "entry_123" // Time entry ID
+}
+```
+
+- **Returns**: [TimeEntryResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/time.py)
+
+```jsonc
+{
+  "id": "entry_123",
+  "task_id": "task_123",
+  "user_id": 789,
+  "team_id": "team_1",
+  "description": "Work on feature",
+  "duration": 3600000,
+  "start": 1731523200000,
+  "end": 1731526800000
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when time entry does not exist
+  - `RATE_LIMIT` (429)
+
+### time_entry.list
+
+Lists time entries for a team with optional filtering. Read-only.
+- **Parameters**: [TimeEntryListInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/time.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "task_id": "task_123", // Optional: filter by task
+  "start_date": 1731523200000, // Optional: start date epoch ms
+  "end_date": 1731526800000, // Optional: end date epoch ms
+  "assignee": 789, // Optional: filter by assignee ID
+  "page": 0, // Optional: page number (default 0)
+  "limit": 100 // Optional: page size (default 100, max 100)
+}
+```
+
+- **Returns**: [TimeEntryListResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/time.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "items": [
+      {
+        "id": "entry_123",
+        "task_id": "task_123",
+        "user_id": 789,
+        "duration": 3600000
+      }
+    ],
+    "page": 0,
+    "limit": 100,
+    "total": 50
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `VALIDATION_ERROR` when date range is invalid
+  - `RATE_LIMIT` (429)
+
+### time_entry.update
+
+Updates an existing time entry. This operation modifies ClickUp data.
+- **Parameters**: [TimeEntryUpdateInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/time.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "time_entry_id": "entry_123", // Time entry ID
+  "description": "Updated description", // Optional new description
+  "start": 1731523300000, // Optional new start time
+  "end": 1731526900000, // Optional new end time
+  "duration": 3600000 // Optional new duration
+}
+```
+
+- **Returns**: [TimeEntryResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/time.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "id": "entry_123",
+    "task_id": "task_123",
+    "description": "Updated description",
+    "duration": 3600000
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when time entry does not exist
+  - `VALIDATION_ERROR` when update data is invalid
+  - `RATE_LIMIT` (429)
+
+### time_entry.delete
+
+Deletes a time entry by ID. This operation permanently removes data from ClickUp.
+- **Parameters**: [TimeEntryDeleteInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/time.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "time_entry_id": "entry_123" // Time entry ID to delete
+}
+```
+
+- **Returns**: [DeletionResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/common.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "deleted": true,
+    "id": "entry_123"
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when time entry does not exist
+  - `RATE_LIMIT` (429)
+
+### time_tracking.start
+
+Starts time tracking for a task. This operation modifies ClickUp data.
+- **Parameters**: [TimeTrackingStartInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/time.py)
+
+```jsonc
+{
+  "task_id": "task_123" // Task ID to track time for
+}
+```
+
+- **Returns**: [OperationResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/common.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "success": true,
+    "message": "Time tracking started"
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when task_id is invalid
+  - `RATE_LIMIT` (429)
+
+### time_tracking.stop
+
+Stops time tracking for a task with an optional description. This operation modifies ClickUp data.
+- **Parameters**: [TimeTrackingStopInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/time.py)
+
+```jsonc
+{
+  "task_id": "task_123", // Task ID to stop tracking for
+  "description": "Completed work" // Optional description for the time entry
+}
+```
+
+- **Returns**: [OperationResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/common.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "success": true,
+    "message": "Time tracking stopped"
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when task_id is invalid
+  - `RATE_LIMIT` (429)
+
+### time_tracking.get_status
+
+Gets the current time tracking status for a task. Read-only.
+- **Parameters**: [TimeTrackingGetInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/time.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "task_id": "task_123" // Task ID to check tracking status
+}
+```
+
+- **Returns**: [TimeTrackingStatus](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/time.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "active": true, // Whether tracking is active
+    "duration": 3600000, // Current duration in ms
+    "start": 1731523200000, // Start time epoch ms
+    "user_id": 789 // User tracking time
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when task_id is invalid
+  - `RATE_LIMIT` (429)

--- a/docs/contents/document/api-references/mcp-server/tools/workflow.mdx
+++ b/docs/contents/document/api-references/mcp-server/tools/workflow.mdx
@@ -1,0 +1,203 @@
+---
+id: workflow-mcp-api
+title: Workflow
+sidebar_position: 9
+---
+
+# Workflow MCP API
+
+Tools for managing ClickUp workflow automations, including creating, retrieving, listing, updating, and deleting workflow automations with triggers and actions.
+
+:::note Errors and retries
+All MCP tools return a uniform ToolResponse envelope (`ok`, `result`, `issues[]`). When `ok: false`, inspect `issues` 
+and apply retries/backoff (respect `retry_after_ms` for 429 and back off on 5xx/transient errors). See 
+[Errors and Retries (MCP)](../errors-and-retries.mdx) for details.
+:::
+
+## Tools
+
+### workflow.create
+
+Creates a new workflow automation with name, trigger type, trigger config, and actions. This operation modifies ClickUp data and returns the created workflow.
+- **Parameters**: [WorkflowCreateInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/workflow.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "name": "Auto-assign on create", // Workflow name
+  "description": "Automatically assign tasks on creation", // Optional description
+  "trigger_type": "task_created", // Trigger type (e.g., task_created, status_changed)
+  "trigger_config": {"list_id": "456"}, // Trigger configuration
+  "actions": [{"type": "assign", "user_id": "789"}], // List of actions to execute
+  "is_active": true, // Optional: whether workflow is active (default true)
+  "priority": 1 // Optional: execution priority
+}
+```
+
+- **Returns**: [WorkflowResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/workflow.py) in `ToolResponse`
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "id": "wf_123", // Workflow ID
+    "team_id": "team_1", // Team/workspace ID
+    "name": "Auto-assign on create", // Workflow name
+    "description": "Automatically assign tasks on creation", // Description
+    "trigger_type": "task_created", // Trigger type
+    "trigger_config": {"list_id": "456"}, // Trigger configuration
+    "actions": [{"type": "assign", "user_id": "789"}], // Actions
+    "is_active": true, // Active flag
+    "priority": 1, // Priority
+    "date_created": 1702080000000, // Creation date epoch ms
+    "date_updated": 1702080000000 // Last update epoch ms
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `VALIDATION_ERROR` when required fields are missing
+  - `NOT_FOUND` (404) when team_id is invalid
+  - `RATE_LIMIT` (429)
+  - `UPSTREAM_ERROR` (5xx/timeout)
+
+### workflow.get
+
+Retrieves a single workflow automation by ID. Read-only.
+- **Parameters**: [WorkflowGetInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/workflow.py)
+
+```jsonc
+{
+  "workflow_id": "wf_123" // Workflow ID
+}
+```
+
+- **Returns**: [WorkflowResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/workflow.py)
+
+```jsonc
+{
+  "id": "wf_123",
+  "team_id": "team_1",
+  "name": "Auto-assign on create",
+  "trigger_type": "task_created",
+  "trigger_config": {"list_id": "456"},
+  "actions": [{"type": "assign", "user_id": "789"}],
+  "is_active": true
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when workflow does not exist
+  - `RATE_LIMIT` (429)
+
+### workflow.list
+
+Lists workflow automations for a team with optional filtering by active status and pagination. Read-only.
+- **Parameters**: [WorkflowListInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/workflow.py)
+
+```jsonc
+{
+  "team_id": "team_1", // Team/workspace ID
+  "page": 0, // Optional: page number (default 0)
+  "limit": 100, // Optional: page size (default 100, max 100)
+  "is_active": true // Optional: filter by active status
+}
+```
+
+- **Returns**: [WorkflowListResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/workflow.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "items": [
+      {
+        "id": "wf_123",
+        "team_id": "team_1",
+        "name": "Auto-assign on create",
+        "trigger_type": "task_created",
+        "is_active": true
+      }
+    ],
+    "page": 0,
+    "limit": 100,
+    "total": 10
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `RATE_LIMIT` (429)
+
+### workflow.update
+
+Updates an existing workflow automation. This operation modifies ClickUp data.
+- **Parameters**: [WorkflowUpdateInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/workflow.py)
+
+```jsonc
+{
+  "workflow_id": "wf_123", // Workflow ID
+  "name": "Updated name", // Optional new name
+  "description": "Updated description", // Optional new description
+  "trigger_type": "status_changed", // Optional new trigger type
+  "trigger_config": {"list_id": "789"}, // Optional new trigger config
+  "actions": [{"type": "assign", "user_id": "790"}], // Optional new actions
+  "is_active": false, // Optional new active status
+  "priority": 2 // Optional new priority
+}
+```
+
+- **Returns**: [WorkflowResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/workflow.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "id": "wf_123",
+    "name": "Updated name",
+    "trigger_type": "status_changed",
+    "is_active": false
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when workflow does not exist
+  - `VALIDATION_ERROR` when update data is invalid
+  - `RATE_LIMIT` (429)
+
+### workflow.delete
+
+Deletes a workflow automation by ID. This operation permanently removes data from ClickUp.
+- **Parameters**: [WorkflowDeleteInput](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/inputs/workflow.py)
+
+```jsonc
+{
+  "workflow_id": "wf_123" // Workflow ID to delete
+}
+```
+
+- **Returns**: [DeletionResult](https://github.com/Chisanan232/clickup-mcp-server/blob/master/clickup_mcp/mcp_server/models/outputs/common.py)
+
+```jsonc
+{
+  "ok": true,
+  "result": {
+    "deleted": true,
+    "id": "wf_123"
+  },
+  "issues": []
+}
+```
+
+- **Errors**
+  - `AUTH_ERROR` (401), `FORBIDDEN` (403)
+  - `NOT_FOUND` (404) when workflow does not exist
+  - `RATE_LIMIT` (429)

--- a/docs/contents/document/quick-start/user-journeys.mdx
+++ b/docs/contents/document/quick-start/user-journeys.mdx
@@ -1,0 +1,419 @@
+---
+id: user-journeys
+title: User Journey Examples
+sidebar_position: 6
+---
+
+# User Journey Examples
+
+This section provides practical user journey examples demonstrating common workflows when using the ClickUp MCP Server.
+
+## Journey 1: Task Management Workflow
+
+### Scenario: Create, Assign, and Track Tasks
+
+This journey demonstrates how to create a task, assign it to a team member, and track its progress.
+
+```python
+# Step 1: Create a task
+response = await mcp.call_tool("task.create", {
+    "list_id": "L123",
+    "name": "Implement user authentication",
+    "description": "Add OAuth2 authentication for user login",
+    "status": "to do",
+    "priority": 3,
+    "assignees": [789],
+    "due_date": 1731523200000
+})
+
+# Step 2: Get the task details
+task_response = await mcp.call_tool("task.get", {
+    "task_id": response.result.id
+})
+
+# Step 3: Update task status when work begins
+await mcp.call_tool("task.update", {
+    "task_id": response.result.id,
+    "status": "in progress"
+})
+
+# Step 4: Start time tracking for the task
+await mcp.call_tool("time_tracking.start", {
+    "task_id": response.result.id
+})
+
+# Step 5: Stop time tracking when work is complete
+await mcp.call_tool("time_tracking.stop", {
+    "task_id": response.result.id,
+    "description": "Completed authentication implementation"
+})
+
+# Step 6: Mark task as completed
+await mcp.call_tool("task.update", {
+    "task_id": response.result.id,
+    "status": "complete"
+})
+```
+
+## Journey 2: Goal and Key Result Management
+
+### Scenario: Set Up Quarterly Goals with Key Results
+
+This journey demonstrates how to create a goal with key results and track progress.
+
+```python
+# Step 1: Create a quarterly goal
+goal_response = await mcp.call_tool("goal.create", {
+    "team_id": "team_1",
+    "name": "Q1 2024 Revenue Goal",
+    "description": "Achieve $1M in revenue for Q1 2024",
+    "due_date": 1702080000000,
+    "owners": [789],
+    "multiple_owners": false
+})
+
+# Step 2: Add key results to the goal
+await mcp.call_tool("key_result.create", {
+    "goal_id": goal_response.result.id,
+    "name": "Increase Monthly Recurring Revenue",
+    "type": "currency",
+    "target": 1000000,
+    "unit": "$",
+    "description": "Increase MRR from $500K to $1M",
+    "start_value": 500000,
+    "current_value": 750000
+})
+
+await mcp.call_tool("key_result.create", {
+    "goal_id": goal_response.result.id,
+    "name": "Acquire New Customers",
+    "type": "number",
+    "target": 100,
+    "unit": "customers",
+    "description": "Acquire 100 new enterprise customers",
+    "start_value": 0,
+    "current_value": 45
+})
+
+# Step 3: Update key result progress
+await mcp.call_tool("key_result.update", {
+    "key_result_id": "kr_123",
+    "current_value": 850000,
+    "status": "on_track"
+})
+
+# Step 4: List all goals for the team
+goals = await mcp.call_tool("goal.list", {
+    "team_id": "team_1",
+    "status": "active"
+})
+```
+
+## Journey 3: Workflow Automation Setup
+
+### Scenario: Automate Task Assignment Based on Status
+
+This journey demonstrates how to create a workflow automation that automatically assigns tasks when status changes.
+
+```python
+# Step 1: Create a workflow automation
+workflow_response = await mcp.call_tool("workflow.create", {
+    "team_id": "team_1",
+    "name": "Auto-assign on status change",
+    "description": "Automatically assign tasks to team lead when status changes to 'in review'",
+    "trigger_type": "status_changed",
+    "trigger_config": {
+        "from_status": "in progress",
+        "to_status": "in review"
+    },
+    "actions": [
+        {
+            "type": "assign",
+            "user_id": 789
+        },
+        {
+            "type": "add_comment",
+            "comment": "Task assigned to team lead for review"
+        }
+    ],
+    "is_active": true,
+    "priority": 1
+})
+
+# Step 2: List all active workflows
+workflows = await mcp.call_tool("workflow.list", {
+    "team_id": "team_1",
+    "is_active": true
+})
+
+# Step 3: Update workflow if needed
+await mcp.call_tool("workflow.update", {
+    "workflow_id": workflow_response.result.id,
+    "is_active": false
+})
+```
+
+## Journey 4: Time Tracking and Reporting
+
+### Scenario: Track Time and Generate Reports
+
+This journey demonstrates how to track time for tasks and generate time reports.
+
+```python
+# Step 1: Create time entries for completed work
+await mcp.call_tool("time_entry.create", {
+    "team_id": "team_1",
+    "task_id": "task_123",
+    "description": "Worked on authentication feature",
+    "duration": 3600000,  # 1 hour in milliseconds
+    "start": 1702080000000,
+    "end": 1702083600000
+})
+
+await mcp.call_tool("time_entry.create", {
+    "team_id": "team_1",
+    "task_id": "task_123",
+    "description": "Code review",
+    "duration": 1800000,  # 30 minutes
+    "start": 1702083600000,
+    "end": 1702085400000
+})
+
+# Step 2: Create a time report for a date range
+report = await mcp.call_tool("report.create", {
+    "team_id": "team_1",
+    "start_date": 1702080000000,
+    "end_date": 1702166400000,
+    "assignee": 789
+})
+
+# Step 3: List time entries with filters
+time_entries = await mcp.call_tool("time_entry.list", {
+    "team_id": "team_1",
+    "task_id": "task_123",
+    "start_date": 1702080000000,
+    "end_date": 1702166400000,
+    "limit": 100
+})
+
+# Step 4: Get time tracking status for a task
+status = await mcp.call_tool("time_tracking.get_status", {
+    "team_id": "team_1",
+    "task_id": "task_123"
+})
+```
+
+## Journey 5: Analytics and Insights
+
+### Scenario: Analyze Team Performance and Detect Bottlenecks
+
+This journey demonstrates how to use analytics to gain insights into team performance.
+
+```python
+# Step 1: Get task analytics
+task_analytics = await mcp.call_tool("analytics.get_task_analytics", {
+    "team_id": "team_1",
+    "start_date": 1702080000000,
+    "end_date": 1702166400000,
+    "assignee_id": 789
+})
+
+# Step 2: Detect bottlenecks in the workflow
+bottlenecks = await mcp.call_tool("bottleneck.detect", {
+    "team_id": "team_1",
+    "start_date": 1702080000000,
+    "end_date": 1702166400000,
+    "threshold": 5
+})
+
+# Step 3: Generate insights from analytics
+insights = await mcp.call_tool("insights.generate", {
+    "team_id": "team_1",
+    "start_date": 1702080000000,
+    "end_date": 1702166400000,
+    "insight_type": "productivity"
+})
+
+# Step 4: Use insights to improve workflow
+if insights.result.recommendations:
+    for recommendation in insights.result.recommendations:
+        print(f"Recommendation: {recommendation}")
+```
+
+## Journey 6: Workspace and Project Setup
+
+### Scenario: Set Up a New Project Workspace
+
+This journey demonstrates how to set up a new workspace with spaces, folders, and lists.
+
+```python
+# Step 1: Get all workspaces
+workspaces = await mcp.call_tool("workspace.list", {})
+
+# Step 2: Get a specific workspace
+workspace = await mcp.call_tool("workspace.get", {
+    "workspace_id": workspaces.result.items[0].id
+})
+
+# Step 3: Create a new space
+space_response = await mcp.call_tool("space.create", {
+    "team_id": "team_1",
+    "name": "Development",
+    "description": "Development team workspace"
+})
+
+# Step 4: Create folders in the space
+folder_response = await mcp.call_tool("folder.create", {
+    "space_id": space_response.result.id,
+    "name": "Backend",
+    "description": "Backend development tasks"
+})
+
+# Step 5: Create lists in the folder
+list_response = await mcp.call_tool("list.create", {
+    "folder_id": folder_response.result.id,
+    "name": "Sprint 1",
+    "description": "Sprint 1 tasks"
+})
+
+# Step 6: Create tasks in the list
+await mcp.call_tool("task.create", {
+    "list_id": list_response.result.id,
+    "name": "Setup database",
+    "description": "Configure PostgreSQL database",
+    "status": "to do"
+})
+```
+
+## Journey 7: Custom Field Management
+
+### Scenario: Use Custom Fields for Task Metadata
+
+This journey demonstrates how to set and manage custom fields on tasks.
+
+```python
+# Step 1: Create a task with custom fields
+task_response = await mcp.call_tool("task.create", {
+    "list_id": "L123",
+    "name": "Feature implementation",
+    "custom_fields": {
+        "cf_story_points": 8,
+        "cf_priority_level": "high",
+        "cf_sprint": "Sprint 42"
+    }
+})
+
+# Step 2: Set a custom field value
+await mcp.call_tool("task.set_custom_field", {
+    "task_id": task_response.result.id,
+    "field_id": "cf_story_points",
+    "value": 13
+})
+
+# Step 3: Clear a custom field value
+await mcp.call_tool("task.clear_custom_field", {
+    "task_id": task_response.result.id,
+    "field_id": "cf_sprint"
+})
+
+# Step 4: Get task to verify custom fields
+task = await mcp.call_tool("task.get", {
+    "task_id": task_response.result.id
+})
+```
+
+## Journey 8: Task Dependencies
+
+### Scenario: Manage Task Dependencies
+
+This journey demonstrates how to set up and manage task dependencies.
+
+```python
+# Step 1: Create parent task
+parent_task = await mcp.call_tool("task.create", {
+    "list_id": "L123",
+    "name": "Implement API endpoint",
+    "status": "to do"
+})
+
+# Step 2: Create dependent task
+dependent_task = await mcp.call_tool("task.create", {
+    "list_id": "L123",
+    "name": "Write API tests",
+    "status": "to do",
+    "parent": parent_task.result.id
+})
+
+# Step 3: Add explicit dependency
+await mcp.call_tool("task.add_dependency", {
+    "task_id": dependent_task.result.id,
+    "depends_on": parent_task.result.id
+})
+
+# Step 4: List tasks with dependencies
+tasks = await mcp.call_tool("task.list_in_list", {
+    "list_id": "L123",
+    "include_subtasks": true
+})
+```
+
+## Best Practices
+
+### Error Handling
+
+Always check the `ok` field in the response and handle errors appropriately:
+
+```python
+response = await mcp.call_tool("task.create", {...})
+if not response.ok:
+    for issue in response.issues:
+        print(f"Error: {issue.code} - {issue.message}")
+        if issue.retry_after_ms:
+            print(f"Retry after: {issue.retry_after_ms}ms")
+```
+
+### Pagination
+
+When working with list operations, handle pagination:
+
+```python
+page = 0
+limit = 100
+all_items = []
+
+while True:
+    response = await mcp.call_tool("task.list_in_list", {
+        "list_id": "L123",
+        "page": page,
+        "limit": limit
+    })
+    all_items.extend(response.result.items)
+    
+    if not response.result.next_cursor:
+        break
+    page += 1
+```
+
+### Rate Limiting
+
+Respect rate limits by implementing backoff:
+
+```python
+import asyncio
+
+async def call_with_retry(tool_name, args, max_retries=3):
+    for attempt in range(max_retries):
+        response = await mcp.call_tool(tool_name, args)
+        if response.ok:
+            return response
+        
+        # Check for rate limit
+        for issue in response.issues:
+            if issue.code == "RATE_LIMIT" and issue.retry_after_ms:
+                await asyncio.sleep(issue.retry_after_ms / 1000)
+                continue
+        
+        # For other errors, return the response
+        return response
+    return response
+```

--- a/test/integration_test/test_api_integration.py
+++ b/test/integration_test/test_api_integration.py
@@ -5,15 +5,16 @@ This module tests the integration of different API components to ensure
 they work together properly in a realistic scenario with minimal mocking.
 """
 
-import pytest
 from unittest.mock import MagicMock
 
-from clickup_mcp.client import ClickUpAPIClient
+import pytest
+
+from clickup_mcp.api.analytics import AnalyticsAPI
+from clickup_mcp.api.goal import GoalAPI
 from clickup_mcp.api.task import TaskAPI
 from clickup_mcp.api.time import TimeAPI
-from clickup_mcp.api.goal import GoalAPI
 from clickup_mcp.api.workflow import WorkflowAPI
-from clickup_mcp.api.analytics import AnalyticsAPI
+from clickup_mcp.client import ClickUpAPIClient
 from clickup_mcp.models.http import APIResponse
 
 
@@ -159,8 +160,8 @@ class TestAPIIntegration:
         ]
 
         # Act - Create a workflow and then create a task that triggers it
-        from clickup_mcp.models.dto.workflow import WorkflowCreate
         from clickup_mcp.models.dto.task import TaskCreate
+        from clickup_mcp.models.dto.workflow import WorkflowCreate
 
         workflow = await workflow_api.create(
             "team_001",
@@ -197,8 +198,8 @@ class TestAPIIntegration:
         )
 
         # Act - Create tasks and then get analytics
-        from clickup_mcp.models.dto.task import TaskCreate
         from clickup_mcp.models.dto.analytics import TaskAnalyticsQuery
+        from clickup_mcp.models.dto.task import TaskCreate
 
         task1 = await task_api.create(TaskCreate(name="Task 1", list_id="list_123"))
         task2 = await task_api.create(TaskCreate(name="Task 2", list_id="list_123"))
@@ -260,8 +261,8 @@ class TestAPIIntegration:
         mock_client.post.side_effect = mock_response_generator
 
         # Act - Complete workflow: create task, track time, create goal
-        from clickup_mcp.models.dto.task import TaskCreate
         from clickup_mcp.models.dto.goal import GoalCreate
+        from clickup_mcp.models.dto.task import TaskCreate
 
         task = await task_api.create(TaskCreate(name="Test Task", list_id="list_123"))
         tracking_started = await time_api.start_tracking("task_123")

--- a/test/integration_test/test_api_integration.py
+++ b/test/integration_test/test_api_integration.py
@@ -1,0 +1,283 @@
+"""
+Integration tests for API components.
+
+This module tests the integration of different API components to ensure
+they work together properly in a realistic scenario with minimal mocking.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from clickup_mcp.client import ClickUpAPIClient
+from clickup_mcp.api.task import TaskAPI
+from clickup_mcp.api.time import TimeAPI
+from clickup_mcp.api.goal import GoalAPI
+from clickup_mcp.api.workflow import WorkflowAPI
+from clickup_mcp.api.analytics import AnalyticsAPI
+from clickup_mcp.models.http import APIResponse
+
+
+class TestAPIIntegration:
+    """Integration test suite for API components."""
+
+    @pytest.mark.asyncio
+    async def test_task_and_time_integration(self):
+        """Test integration between task and time tracking APIs."""
+        # Arrange
+        mock_client = MagicMock(spec=ClickUpAPIClient)
+        task_api = TaskAPI(mock_client)
+        time_api = TimeAPI(mock_client)
+
+        # Mock responses
+        mock_client.post.side_effect = [
+            APIResponse(
+                success=True,
+                status_code=200,
+                data={
+                    "id": "task_123",
+                    "name": "Test Task",
+                    "description": "Test Description",
+                },
+                headers={},
+            ),
+            APIResponse(
+                success=True,
+                status_code=200,
+                data={
+                    "id": "entry_123",
+                    "task_id": "task_123",
+                    "user_id": 789,
+                    "team_id": "team_001",
+                    "description": "Test work",
+                    "duration": 3600000,
+                },
+                headers={},
+            ),
+        ]
+
+        # Act - Create a task and log time against it
+        from clickup_mcp.models.dto.task import TaskCreate
+        from clickup_mcp.models.dto.time import TimeEntryCreate
+
+        task = await task_api.create(TaskCreate(name="Test Task", list_id="list_123"))
+        time_entry = await time_api.create(
+            "team_001",
+            TimeEntryCreate(task_id="task_123", description="Test work", duration=3600000),
+        )
+
+        # Assert - Both operations should succeed
+        assert task is not None
+        assert time_entry is not None
+        assert time_entry.task_id == "task_123"
+
+    @pytest.mark.asyncio
+    async def test_goal_and_key_result_integration(self):
+        """Test integration between goal and key result APIs."""
+        # Arrange
+        mock_client = MagicMock(spec=ClickUpAPIClient)
+        goal_api = GoalAPI(mock_client)
+
+        # Mock goal creation response
+        mock_client.post.return_value = APIResponse(
+            success=True,
+            status_code=200,
+            data={
+                "items": [
+                    {
+                        "id": "goal_123",
+                        "team_id": "team_001",
+                        "name": "Q1 Revenue Goal",
+                        "description": "Achieve $1M in revenue",
+                        "due_date": 1702080000000,
+                        "status": "active",
+                        "key_results": ["KR1", "KR2"],
+                    }
+                ]
+            },
+            headers={},
+        )
+
+        # Act - Create a goal with key results
+        from clickup_mcp.models.dto.goal import GoalCreate
+
+        goal = await goal_api.create(
+            "team_001",
+            GoalCreate(
+                name="Q1 Revenue Goal",
+                description="Achieve $1M in revenue",
+                due_date=1702080000000,
+                key_results=["KR1", "KR2"],
+            ),
+        )
+
+        # Assert - Goal should be created with key results
+        assert goal is not None
+        assert len(goal.items) == 1
+        assert goal.items[0].key_results == ["KR1", "KR2"]
+
+    @pytest.mark.asyncio
+    async def test_workflow_and_task_integration(self):
+        """Test integration between workflow and task APIs."""
+        # Arrange
+        mock_client = MagicMock(spec=ClickUpAPIClient)
+        workflow_api = WorkflowAPI(mock_client)
+        task_api = TaskAPI(mock_client)
+
+        # Mock workflow creation response
+        mock_client.post.side_effect = [
+            APIResponse(
+                success=True,
+                status_code=200,
+                data={
+                    "items": [
+                        {
+                            "id": "wf_123",
+                            "team_id": "team_001",
+                            "name": "Auto-assign on create",
+                            "trigger_type": "task_created",
+                            "trigger_config": {"list_id": "456"},
+                            "actions": [{"type": "assign", "user_id": "789"}],
+                            "is_active": True,
+                        }
+                    ],
+                    "page": 0,
+                    "limit": 100,
+                },
+                headers={},
+            ),
+            APIResponse(
+                success=True,
+                status_code=200,
+                data={
+                    "id": "task_123",
+                    "name": "Test Task",
+                    "description": "Test Description",
+                    "assignees": [{"id": 789}],
+                },
+                headers={},
+            ),
+        ]
+
+        # Act - Create a workflow and then create a task that triggers it
+        from clickup_mcp.models.dto.workflow import WorkflowCreate
+        from clickup_mcp.models.dto.task import TaskCreate
+
+        workflow = await workflow_api.create(
+            "team_001",
+            WorkflowCreate(
+                name="Auto-assign on create",
+                trigger_type="task_created",
+                trigger_config={"list_id": "456"},
+                actions=[{"type": "assign", "user_id": "789"}],
+            ),
+        )
+
+        task = await task_api.create(TaskCreate(name="Test Task", list_id="456"))
+
+        # Assert - Both operations should succeed
+        assert workflow is not None
+        assert task is not None
+        assert workflow.items[0].trigger_type == "task_created"
+
+    @pytest.mark.asyncio
+    async def test_analytics_and_task_integration(self):
+        """Test integration between analytics and task APIs."""
+        # Arrange
+        mock_client = MagicMock(spec=ClickUpAPIClient)
+        analytics_api = AnalyticsAPI(mock_client)
+        task_api = TaskAPI(mock_client)
+
+        # Mock responses
+        mock_client.get.return_value = {"data": {"id": "a1", "team_id": "team_001", "total_tasks": 100}}
+        mock_client.post.return_value = APIResponse(
+            success=True,
+            status_code=200,
+            data={"id": "task_123", "name": "Test Task"},
+            headers={},
+        )
+
+        # Act - Create tasks and then get analytics
+        from clickup_mcp.models.dto.task import TaskCreate
+        from clickup_mcp.models.dto.analytics import TaskAnalyticsQuery
+
+        task1 = await task_api.create(TaskCreate(name="Task 1", list_id="list_123"))
+        task2 = await task_api.create(TaskCreate(name="Task 2", list_id="list_123"))
+
+        analytics = await analytics_api.get_task_analytics(
+            "team_001",
+            TaskAnalyticsQuery(start_date=1640995200000, end_date=1643673600000),
+        )
+
+        # Assert - Tasks should be created and analytics should be available
+        assert task1 is not None
+        assert task2 is not None
+        assert analytics is not None
+        assert analytics.total_tasks == 100
+
+    @pytest.mark.asyncio
+    async def test_multi_api_workflow(self):
+        """Test a complete workflow using multiple APIs together."""
+        # Arrange
+        mock_client = MagicMock(spec=ClickUpAPIClient)
+        task_api = TaskAPI(mock_client)
+        time_api = TimeAPI(mock_client)
+        goal_api = GoalAPI(mock_client)
+
+        # Mock responses
+        call_count = [0]
+
+        def mock_response_generator(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:  # Create task
+                return APIResponse(
+                    success=True,
+                    status_code=200,
+                    data={"id": "task_123", "name": "Test Task"},
+                    headers={},
+                )
+            elif call_count[0] == 2:  # Start tracking
+                return APIResponse(success=True, status_code=200, data=None, headers={})
+            elif call_count[0] == 3:  # Stop tracking
+                return APIResponse(success=True, status_code=200, data=None, headers={})
+            elif call_count[0] == 4:  # Create goal
+                return APIResponse(
+                    success=True,
+                    status_code=200,
+                    data={
+                        "items": [
+                            {
+                                "id": "goal_123",
+                                "team_id": "team_001",
+                                "name": "Complete Project",
+                                "status": "active",
+                            }
+                        ]
+                    },
+                    headers={},
+                )
+            return APIResponse(success=True, status_code=200, data=None, headers={})
+
+        mock_client.post.side_effect = mock_response_generator
+
+        # Act - Complete workflow: create task, track time, create goal
+        from clickup_mcp.models.dto.task import TaskCreate
+        from clickup_mcp.models.dto.goal import GoalCreate
+
+        task = await task_api.create(TaskCreate(name="Test Task", list_id="list_123"))
+        tracking_started = await time_api.start_tracking("task_123")
+        tracking_stopped = await time_api.stop_tracking("task_123", "Completed work")
+        goal = await goal_api.create(
+            "team_001",
+            GoalCreate(
+                name="Complete Project",
+                description="Complete the project on time",
+                due_date=1702080000000,
+            ),
+        )
+
+        # Assert - All operations should succeed
+        assert task is not None
+        assert tracking_started is True
+        assert tracking_stopped is True
+        assert goal is not None
+        assert goal.items[0].name == "Complete Project"

--- a/test/performance_test.py
+++ b/test/performance_test.py
@@ -5,16 +5,17 @@ This module contains performance benchmarks and load tests to ensure
 the system performs adequately under various conditions.
 """
 
-import pytest
 import asyncio
 import time
-from unittest.mock import MagicMock
 from typing import List
+from unittest.mock import MagicMock
 
-from clickup_mcp.client import ClickUpAPIClient
+import pytest
+
+from clickup_mcp.api.goal import GoalAPI
 from clickup_mcp.api.task import TaskAPI
 from clickup_mcp.api.time import TimeAPI
-from clickup_mcp.api.goal import GoalAPI
+from clickup_mcp.client import ClickUpAPIClient
 from clickup_mcp.models.http import APIResponse
 
 

--- a/test/performance_test.py
+++ b/test/performance_test.py
@@ -1,0 +1,292 @@
+"""
+Performance tests for the ClickUp MCP Server.
+
+This module contains performance benchmarks and load tests to ensure
+the system performs adequately under various conditions.
+"""
+
+import pytest
+import asyncio
+import time
+from unittest.mock import MagicMock
+from typing import List
+
+from clickup_mcp.client import ClickUpAPIClient
+from clickup_mcp.api.task import TaskAPI
+from clickup_mcp.api.time import TimeAPI
+from clickup_mcp.api.goal import GoalAPI
+from clickup_mcp.models.http import APIResponse
+
+
+class TestPerformance:
+    """Performance test suite for the ClickUp MCP Server."""
+
+    @pytest.mark.asyncio
+    async def test_task_api_concurrent_requests(self):
+        """Test task API performance with concurrent requests."""
+        # Arrange
+        mock_client = MagicMock(spec=ClickUpAPIClient)
+        task_api = TaskAPI(mock_client)
+
+        # Mock successful responses
+        mock_client.get.return_value = APIResponse(
+            success=True,
+            status_code=200,
+            data={"id": "task_123", "name": "Test Task"},
+            headers={},
+        )
+
+        # Act - Make 100 concurrent requests
+        start_time = time.time()
+        tasks = [task_api.get("task_123") for _ in range(100)]
+        results = await asyncio.gather(*tasks)
+        end_time = time.time()
+
+        # Assert - All requests should succeed
+        assert all(r is not None for r in results)
+        # Performance assertion - should complete in reasonable time (< 5 seconds for 100 requests)
+        assert end_time - start_time < 5.0
+
+    @pytest.mark.asyncio
+    async def test_time_api_sequential_performance(self):
+        """Test time API sequential operation performance."""
+        # Arrange
+        mock_client = MagicMock(spec=ClickUpAPIClient)
+        time_api = TimeAPI(mock_client)
+
+        mock_client.post.return_value = APIResponse(
+            success=True,
+            status_code=200,
+            data={
+                "id": "entry_123",
+                "task_id": "task_123",
+                "user_id": 789,
+                "team_id": "team_001",
+                "duration": 3600000,
+            },
+            headers={},
+        )
+
+        # Act - Create 50 time entries sequentially
+        start_time = time.time()
+        for _ in range(50):
+            from clickup_mcp.models.dto.time import TimeEntryCreate
+            await time_api.create(
+                "team_001",
+                TimeEntryCreate(task_id="task_123", duration=3600000),
+            )
+        end_time = time.time()
+
+        # Assert - Should complete in reasonable time
+        assert end_time - start_time < 3.0
+
+    @pytest.mark.asyncio
+    async def test_goal_api_batch_operations(self):
+        """Test goal API batch operation performance."""
+        # Arrange
+        mock_client = MagicMock(spec=ClickUpAPIClient)
+        goal_api = GoalAPI(mock_client)
+
+        mock_client.post.return_value = APIResponse(
+            success=True,
+            status_code=200,
+            data={
+                "items": [
+                    {
+                        "id": "goal_123",
+                        "team_id": "team_001",
+                        "name": "Test Goal",
+                        "status": "active",
+                    }
+                ]
+            },
+            headers={},
+        )
+
+        # Act - Create 20 goals in batch
+        start_time = time.time()
+        tasks = [
+            goal_api.create(
+                "team_001",
+                from clickup_mcp.models.dto.goal import GoalCreate
+                and GoalCreate(
+                    name=f"Goal {i}",
+                    description=f"Description {i}",
+                    due_date=1702080000000,
+                ),
+            )
+            for i in range(20)
+        ]
+        results = await asyncio.gather(*tasks)
+        end_time = time.time()
+
+        # Assert - All operations should succeed
+        assert all(r is not None for r in results)
+        # Should complete in reasonable time
+        assert end_time - start_time < 2.0
+
+    @pytest.mark.asyncio
+    async def test_api_response_time_benchmark(self):
+        """Benchmark average API response time."""
+        # Arrange
+        mock_client = MagicMock(spec=ClickUpAPIClient)
+        task_api = TaskAPI(mock_client)
+
+        mock_client.get.return_value = APIResponse(
+            success=True,
+            status_code=200,
+            data={"id": "task_123", "name": "Test Task"},
+            headers={},
+        )
+
+        # Act - Measure response times for 100 requests
+        response_times: List[float] = []
+        for _ in range(100):
+            start = time.time()
+            await task_api.get("task_123")
+            end = time.time()
+            response_times.append(end - start)
+
+        # Assert - Calculate statistics
+        avg_response_time = sum(response_times) / len(response_times)
+        max_response_time = max(response_times)
+
+        # Performance assertions
+        assert avg_response_time < 0.1  # Average < 100ms
+        assert max_response_time < 0.5  # Max < 500ms
+
+    @pytest.mark.asyncio
+    async def test_memory_efficiency_large_dataset(self):
+        """Test memory efficiency with large datasets."""
+        # Arrange
+        mock_client = MagicMock(spec=ClickUpAPIClient)
+        task_api = TaskAPI(mock_client)
+
+        # Mock large response
+        large_data = {
+            "tasks": [
+                {"id": f"task_{i}", "name": f"Task {i}"}
+                for i in range(1000)
+            ]
+        }
+
+        mock_client.get.return_value = APIResponse(
+            success=True,
+            status_code=200,
+            data=large_data,
+            headers={},
+        )
+
+        # Act - Process large dataset
+        start_time = time.time()
+        result = await task_api.get("task_123")
+        end_time = time.time()
+
+        # Assert - Should handle large data efficiently
+        assert result is not None
+        assert end_time - start_time < 1.0
+
+    @pytest.mark.asyncio
+    async def test_rate_limiting_resilience(self):
+        """Test resilience under rate limiting conditions."""
+        # Arrange
+        mock_client = MagicMock(spec=ClickUpAPIClient)
+        task_api = TaskAPI(mock_client)
+
+        call_count = [0]
+
+        def mock_response(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] % 10 == 0:
+                # Simulate rate limit every 10 requests
+                return APIResponse(
+                    success=False,
+                    status_code=429,
+                    data={"err": "Rate limit exceeded"},
+                    headers={"Retry-After": "1"},
+                )
+            return APIResponse(
+                success=True,
+                status_code=200,
+                data={"id": "task_123", "name": "Test Task"},
+                headers={},
+            )
+
+        mock_client.get.return_value = mock_response()
+
+        # Act - Make requests that may hit rate limits
+        start_time = time.time()
+        results = []
+        for _ in range(30):
+            result = await task_api.get("task_123")
+            results.append(result)
+        end_time = time.time()
+
+        # Assert - Should handle rate limits gracefully
+        # Some requests should fail with rate limit
+        failed_count = sum(1 for r in results if r is None)
+        assert failed_count > 0
+        # Should complete in reasonable time despite rate limits
+        assert end_time - start_time < 10.0
+
+    @pytest.mark.asyncio
+    async def test_concurrent_mixed_operations(self):
+        """Test performance with mixed concurrent operations."""
+        # Arrange
+        mock_client = MagicMock(spec=ClickUpAPIClient)
+        task_api = TaskAPI(mock_client)
+        time_api = TimeAPI(mock_client)
+        goal_api = GoalAPI(mock_client)
+
+        # Mock responses
+        mock_client.get.return_value = APIResponse(
+            success=True,
+            status_code=200,
+            data={"id": "task_123", "name": "Test Task"},
+            headers={},
+        )
+        mock_client.post.return_value = APIResponse(
+            success=True,
+            status_code=200,
+            data={
+                "id": "entry_123",
+                "task_id": "task_123",
+                "duration": 3600000,
+            },
+            headers={},
+        )
+
+        # Act - Mix of different operations
+        start_time = time.time()
+        tasks = [
+            # 20 task reads
+            *[task_api.get("task_123") for _ in range(20)],
+            # 10 time entries
+            *[
+                time_api.create(
+                    "team_001",
+                    from clickup_mcp.models.dto.time import TimeEntryCreate
+                    and TimeEntryCreate(task_id="task_123", duration=3600000),
+                )
+                for _ in range(10)
+            ],
+            # 5 goal creations
+            *[
+                goal_api.create(
+                    "team_001",
+                    from clickup_mcp.models.dto.goal import GoalCreate
+                    and GoalCreate(
+                        name=f"Goal {i}",
+                        due_date=1702080000000,
+                    ),
+                )
+                for i in range(5)
+            ],
+        ]
+        results = await asyncio.gather(*tasks)
+        end_time = time.time()
+
+        # Assert - All operations should complete
+        assert all(r is not None for r in results)
+        # Should complete in reasonable time
+        assert end_time - start_time < 5.0

--- a/test/unit_test/api/test_analytics.py
+++ b/test/unit_test/api/test_analytics.py
@@ -8,21 +8,22 @@ Tests the AnalyticsAPI class methods including:
 - Get space analytics
 """
 
-import pytest
 from unittest.mock import MagicMock
 
+import pytest
+
 from clickup_mcp.api.analytics import AnalyticsAPI
-from clickup_mcp.models.dto.analytics import (
-    TaskAnalyticsQuery,
-    TeamAnalyticsQuery,
-    ListAnalyticsQuery,
-    SpaceAnalyticsQuery,
-    TaskAnalyticsResponse,
-    TeamAnalyticsResponse,
-    ListAnalyticsResponse,
-    SpaceAnalyticsResponse,
-)
 from clickup_mcp.client import ClickUpAPIClient
+from clickup_mcp.models.dto.analytics import (
+    ListAnalyticsQuery,
+    ListAnalyticsResponse,
+    SpaceAnalyticsQuery,
+    SpaceAnalyticsResponse,
+    TaskAnalyticsQuery,
+    TaskAnalyticsResponse,
+    TeamAnalyticsQuery,
+    TeamAnalyticsResponse,
+)
 
 
 @pytest.fixture
@@ -107,9 +108,7 @@ class TestAnalyticsAPI:
     """Test cases for AnalyticsAPI."""
 
     @pytest.mark.asyncio
-    async def test_get_task_analytics(
-        self, analytics_api, mock_api_client, sample_task_analytics_data
-    ):
+    async def test_get_task_analytics(self, analytics_api, mock_api_client, sample_task_analytics_data):
         """Test getting task analytics for a team."""
         # Arrange
         team_id = "team_001"
@@ -127,9 +126,7 @@ class TestAnalyticsAPI:
         assert result.total_tasks == 100
 
     @pytest.mark.asyncio
-    async def test_get_task_analytics_with_filters(
-        self, analytics_api, mock_api_client, sample_task_analytics_data
-    ):
+    async def test_get_task_analytics_with_filters(self, analytics_api, mock_api_client, sample_task_analytics_data):
         """Test getting task analytics with filters."""
         # Arrange
         team_id = "team_001"
@@ -150,9 +147,7 @@ class TestAnalyticsAPI:
         assert call_args[1]["params"]["status"] == "open"
 
     @pytest.mark.asyncio
-    async def test_get_task_analytics_returns_none_on_failure(
-        self, analytics_api, mock_api_client
-    ):
+    async def test_get_task_analytics_returns_none_on_failure(self, analytics_api, mock_api_client):
         """Test getting task analytics that fails returns None."""
         # Arrange
         team_id = "team_001"
@@ -166,9 +161,7 @@ class TestAnalyticsAPI:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_get_team_analytics(
-        self, analytics_api, mock_api_client, sample_team_analytics_data
-    ):
+    async def test_get_team_analytics(self, analytics_api, mock_api_client, sample_team_analytics_data):
         """Test getting team analytics."""
         # Arrange
         team_id = "team_001"
@@ -186,9 +179,7 @@ class TestAnalyticsAPI:
         assert result.total_tasks == 500
 
     @pytest.mark.asyncio
-    async def test_get_team_analytics_returns_none_on_failure(
-        self, analytics_api, mock_api_client
-    ):
+    async def test_get_team_analytics_returns_none_on_failure(self, analytics_api, mock_api_client):
         """Test getting team analytics that fails returns None."""
         # Arrange
         team_id = "team_001"
@@ -202,9 +193,7 @@ class TestAnalyticsAPI:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_get_list_analytics(
-        self, analytics_api, mock_api_client, sample_list_analytics_data
-    ):
+    async def test_get_list_analytics(self, analytics_api, mock_api_client, sample_list_analytics_data):
         """Test getting list analytics."""
         # Arrange
         list_id = "list_123"
@@ -222,9 +211,7 @@ class TestAnalyticsAPI:
         assert result.total_tasks == 50
 
     @pytest.mark.asyncio
-    async def test_get_list_analytics_returns_none_on_failure(
-        self, analytics_api, mock_api_client
-    ):
+    async def test_get_list_analytics_returns_none_on_failure(self, analytics_api, mock_api_client):
         """Test getting list analytics that fails returns None."""
         # Arrange
         list_id = "list_123"
@@ -238,9 +225,7 @@ class TestAnalyticsAPI:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_get_space_analytics(
-        self, analytics_api, mock_api_client, sample_space_analytics_data
-    ):
+    async def test_get_space_analytics(self, analytics_api, mock_api_client, sample_space_analytics_data):
         """Test getting space analytics."""
         # Arrange
         space_id = "space_123"
@@ -258,9 +243,7 @@ class TestAnalyticsAPI:
         assert result.total_tasks == 200
 
     @pytest.mark.asyncio
-    async def test_get_space_analytics_returns_none_on_failure(
-        self, analytics_api, mock_api_client
-    ):
+    async def test_get_space_analytics_returns_none_on_failure(self, analytics_api, mock_api_client):
         """Test getting space analytics that fails returns None."""
         # Arrange
         space_id = "space_123"

--- a/test/unit_test/api/test_analytics.py
+++ b/test/unit_test/api/test_analytics.py
@@ -1,0 +1,274 @@
+"""
+Unit tests for the Analytics API.
+
+Tests the AnalyticsAPI class methods including:
+- Get task analytics
+- Get team analytics
+- Get list analytics
+- Get space analytics
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from clickup_mcp.api.analytics import AnalyticsAPI
+from clickup_mcp.models.dto.analytics import (
+    TaskAnalyticsQuery,
+    TeamAnalyticsQuery,
+    ListAnalyticsQuery,
+    SpaceAnalyticsQuery,
+    TaskAnalyticsResponse,
+    TeamAnalyticsResponse,
+    ListAnalyticsResponse,
+    SpaceAnalyticsResponse,
+)
+from clickup_mcp.client import ClickUpAPIClient
+
+
+@pytest.fixture
+def mock_api_client() -> MagicMock:
+    """Create a mock API client."""
+    client = MagicMock(spec=ClickUpAPIClient)
+    return client
+
+
+@pytest.fixture
+def analytics_api(mock_api_client: MagicMock) -> AnalyticsAPI:
+    """Create an AnalyticsAPI instance with mock client."""
+    return AnalyticsAPI(mock_api_client)
+
+
+@pytest.fixture
+def sample_task_analytics_data() -> dict:
+    """Sample task analytics data for testing."""
+    return {
+        "id": "a1",
+        "team_id": "team_001",
+        "list_id": "list_123",
+        "start_date": 1640995200000,
+        "end_date": 1643673600000,
+        "total_tasks": 100,
+        "completed_tasks": 75,
+        "in_progress_tasks": 15,
+        "blocked_tasks": 10,
+        "average_completion_time": 86400000,
+        "assignee_metrics": {"user_123": {"completed": 30, "in_progress": 5}},
+        "status_metrics": {"open": 10, "in progress": 15, "closed": 75},
+    }
+
+
+@pytest.fixture
+def sample_team_analytics_data() -> dict:
+    """Sample team analytics data for testing."""
+    return {
+        "id": "a2",
+        "team_id": "team_001",
+        "start_date": 1640995200000,
+        "end_date": 1643673600000,
+        "total_tasks": 500,
+        "completed_tasks": 400,
+        "total_lists": 10,
+        "active_users": 25,
+        "average_task_completion_time": 86400000,
+    }
+
+
+@pytest.fixture
+def sample_list_analytics_data() -> dict:
+    """Sample list analytics data for testing."""
+    return {
+        "id": "a3",
+        "list_id": "list_123",
+        "start_date": 1640995200000,
+        "end_date": 1643673600000,
+        "total_tasks": 50,
+        "completed_tasks": 40,
+        "overdue_tasks": 5,
+        "average_completion_time": 86400000,
+    }
+
+
+@pytest.fixture
+def sample_space_analytics_data() -> dict:
+    """Sample space analytics data for testing."""
+    return {
+        "id": "a4",
+        "space_id": "space_123",
+        "start_date": 1640995200000,
+        "end_date": 1643673600000,
+        "total_tasks": 200,
+        "completed_tasks": 150,
+        "total_lists": 5,
+        "total_folders": 3,
+    }
+
+
+class TestAnalyticsAPI:
+    """Test cases for AnalyticsAPI."""
+
+    @pytest.mark.asyncio
+    async def test_get_task_analytics(
+        self, analytics_api, mock_api_client, sample_task_analytics_data
+    ):
+        """Test getting task analytics for a team."""
+        # Arrange
+        team_id = "team_001"
+        query = TaskAnalyticsQuery(start_date=1640995200000, end_date=1643673600000)
+        mock_api_client.get.return_value = {"data": sample_task_analytics_data}
+
+        # Act
+        result = await analytics_api.get_task_analytics(team_id, query)
+
+        # Assert
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == f"/team/{team_id}/analytics/task"
+        assert isinstance(result, TaskAnalyticsResponse)
+        assert result.total_tasks == 100
+
+    @pytest.mark.asyncio
+    async def test_get_task_analytics_with_filters(
+        self, analytics_api, mock_api_client, sample_task_analytics_data
+    ):
+        """Test getting task analytics with filters."""
+        # Arrange
+        team_id = "team_001"
+        query = TaskAnalyticsQuery(
+            start_date=1640995200000,
+            end_date=1643673600000,
+            assignee_id="user_123",
+            status="open",
+        )
+        mock_api_client.get.return_value = {"data": sample_task_analytics_data}
+
+        # Act
+        result = await analytics_api.get_task_analytics(team_id, query)
+
+        # Assert
+        call_args = mock_api_client.get.call_args
+        assert call_args[1]["params"]["assignee_id"] == "user_123"
+        assert call_args[1]["params"]["status"] == "open"
+
+    @pytest.mark.asyncio
+    async def test_get_task_analytics_returns_none_on_failure(
+        self, analytics_api, mock_api_client
+    ):
+        """Test getting task analytics that fails returns None."""
+        # Arrange
+        team_id = "team_001"
+        query = TaskAnalyticsQuery(start_date=1640995200000, end_date=1643673600000)
+        mock_api_client.get.return_value = None
+
+        # Act
+        result = await analytics_api.get_task_analytics(team_id, query)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_team_analytics(
+        self, analytics_api, mock_api_client, sample_team_analytics_data
+    ):
+        """Test getting team analytics."""
+        # Arrange
+        team_id = "team_001"
+        query = TeamAnalyticsQuery(start_date=1640995200000, end_date=1643673600000)
+        mock_api_client.get.return_value = {"data": sample_team_analytics_data}
+
+        # Act
+        result = await analytics_api.get_team_analytics(team_id, query)
+
+        # Assert
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == f"/team/{team_id}/analytics/team"
+        assert isinstance(result, TeamAnalyticsResponse)
+        assert result.total_tasks == 500
+
+    @pytest.mark.asyncio
+    async def test_get_team_analytics_returns_none_on_failure(
+        self, analytics_api, mock_api_client
+    ):
+        """Test getting team analytics that fails returns None."""
+        # Arrange
+        team_id = "team_001"
+        query = TeamAnalyticsQuery(start_date=1640995200000, end_date=1643673600000)
+        mock_api_client.get.return_value = None
+
+        # Act
+        result = await analytics_api.get_team_analytics(team_id, query)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_list_analytics(
+        self, analytics_api, mock_api_client, sample_list_analytics_data
+    ):
+        """Test getting list analytics."""
+        # Arrange
+        list_id = "list_123"
+        query = ListAnalyticsQuery(start_date=1640995200000, end_date=1643673600000)
+        mock_api_client.get.return_value = {"data": sample_list_analytics_data}
+
+        # Act
+        result = await analytics_api.get_list_analytics(list_id, query)
+
+        # Assert
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == f"/list/{list_id}/analytics"
+        assert isinstance(result, ListAnalyticsResponse)
+        assert result.total_tasks == 50
+
+    @pytest.mark.asyncio
+    async def test_get_list_analytics_returns_none_on_failure(
+        self, analytics_api, mock_api_client
+    ):
+        """Test getting list analytics that fails returns None."""
+        # Arrange
+        list_id = "list_123"
+        query = ListAnalyticsQuery(start_date=1640995200000, end_date=1643673600000)
+        mock_api_client.get.return_value = None
+
+        # Act
+        result = await analytics_api.get_list_analytics(list_id, query)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_space_analytics(
+        self, analytics_api, mock_api_client, sample_space_analytics_data
+    ):
+        """Test getting space analytics."""
+        # Arrange
+        space_id = "space_123"
+        query = SpaceAnalyticsQuery(start_date=1640995200000, end_date=1643673600000)
+        mock_api_client.get.return_value = {"data": sample_space_analytics_data}
+
+        # Act
+        result = await analytics_api.get_space_analytics(space_id, query)
+
+        # Assert
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == f"/space/{space_id}/analytics"
+        assert isinstance(result, SpaceAnalyticsResponse)
+        assert result.total_tasks == 200
+
+    @pytest.mark.asyncio
+    async def test_get_space_analytics_returns_none_on_failure(
+        self, analytics_api, mock_api_client
+    ):
+        """Test getting space analytics that fails returns None."""
+        # Arrange
+        space_id = "space_123"
+        query = SpaceAnalyticsQuery(start_date=1640995200000, end_date=1643673600000)
+        mock_api_client.get.return_value = None
+
+        # Act
+        result = await analytics_api.get_space_analytics(space_id, query)
+
+        # Assert
+        assert result is None

--- a/test/unit_test/api/test_goal.py
+++ b/test/unit_test/api/test_goal.py
@@ -9,17 +9,18 @@ Tests the GoalAPI class methods including:
 - List goals
 """
 
-import pytest
 from unittest.mock import MagicMock
 
+import pytest
+
 from clickup_mcp.api.goal import GoalAPI
+from clickup_mcp.client import ClickUpAPIClient
 from clickup_mcp.models.dto.goal import (
     GoalCreate,
     GoalListQuery,
-    GoalUpdate,
     GoalListResponse,
+    GoalUpdate,
 )
-from clickup_mcp.client import ClickUpAPIClient
 from clickup_mcp.models.http import APIResponse
 
 
@@ -95,9 +96,7 @@ class TestGoalAPI:
         """Test creating a goal."""
         # Arrange
         team_id = "team_001"
-        goal_create = GoalCreate(
-            name="Q1 Revenue Goal", description="Achieve $1M in revenue", due_date=1702080000000
-        )
+        goal_create = GoalCreate(name="Q1 Revenue Goal", description="Achieve $1M in revenue", due_date=1702080000000)
         mock_api_client.post.return_value = APIResponse(
             success=True, status_code=200, data=sample_goal_list_data, headers={}
         )
@@ -117,9 +116,7 @@ class TestGoalAPI:
         """Test creating a goal that fails returns None."""
         # Arrange
         team_id = "team_001"
-        goal_create = GoalCreate(
-            name="Q1 Revenue Goal", description="Achieve $1M in revenue", due_date=1702080000000
-        )
+        goal_create = GoalCreate(name="Q1 Revenue Goal", description="Achieve $1M in revenue", due_date=1702080000000)
         mock_api_client.post.return_value = APIResponse(
             success=False, status_code=400, data={"err": "Invalid request"}, headers={}
         )
@@ -135,9 +132,7 @@ class TestGoalAPI:
         """Test getting a goal by ID."""
         # Arrange
         goal_id = "goal_123"
-        mock_api_client.get.return_value = APIResponse(
-            success=True, status_code=200, data=sample_goal_data, headers={}
-        )
+        mock_api_client.get.return_value = APIResponse(success=True, status_code=200, data=sample_goal_data, headers={})
 
         # Act
         result = await goal_api.get(goal_id)
@@ -168,9 +163,7 @@ class TestGoalAPI:
         # Arrange
         goal_id = "goal_123"
         goal_update = GoalUpdate(name="Updated Goal Name")
-        mock_api_client.put.return_value = APIResponse(
-            success=True, status_code=200, data=sample_goal_data, headers={}
-        )
+        mock_api_client.put.return_value = APIResponse(success=True, status_code=200, data=sample_goal_data, headers={})
 
         # Act
         result = await goal_api.update(goal_id, goal_update)
@@ -203,9 +196,7 @@ class TestGoalAPI:
         """Test deleting a goal."""
         # Arrange
         goal_id = "goal_123"
-        mock_api_client.delete.return_value = APIResponse(
-            success=True, status_code=200, data=None, headers={}
-        )
+        mock_api_client.delete.return_value = APIResponse(success=True, status_code=200, data=None, headers={})
 
         # Act
         result = await goal_api.delete(goal_id)
@@ -270,9 +261,7 @@ class TestGoalAPI:
         """Test listing goals with multiple filters."""
         # Arrange
         team_id = "team_001"
-        query = GoalListQuery(
-            status="active", owner="user_123", start_date=1702080000000, end_date=1702083600000
-        )
+        query = GoalListQuery(status="active", owner="user_123", start_date=1702080000000, end_date=1702083600000)
         mock_api_client.get.return_value = APIResponse(
             success=True, status_code=200, data=sample_goal_list_data, headers={}
         )

--- a/test/unit_test/api/test_goal.py
+++ b/test/unit_test/api/test_goal.py
@@ -1,0 +1,289 @@
+"""
+Unit tests for the Goal API.
+
+Tests the GoalAPI class methods including:
+- Create goal
+- Get goal
+- Update goal
+- Delete goal
+- List goals
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from clickup_mcp.api.goal import GoalAPI
+from clickup_mcp.models.dto.goal import (
+    GoalCreate,
+    GoalListQuery,
+    GoalUpdate,
+    GoalListResponse,
+)
+from clickup_mcp.client import ClickUpAPIClient
+from clickup_mcp.models.http import APIResponse
+
+
+@pytest.fixture
+def mock_api_client() -> MagicMock:
+    """Create a mock API client."""
+    client = MagicMock(spec=ClickUpAPIClient)
+    return client
+
+
+@pytest.fixture
+def goal_api(mock_api_client: MagicMock) -> GoalAPI:
+    """Create a GoalAPI instance with mock client."""
+    return GoalAPI(mock_api_client)
+
+
+@pytest.fixture
+def sample_goal_data() -> dict:
+    """Sample goal data for testing."""
+    return {
+        "id": "goal_123",
+        "team_id": "team_001",
+        "name": "Q1 Revenue Goal",
+        "description": "Achieve $1M in revenue",
+        "due_date": 1702080000000,
+        "status": "active",
+        "key_results": ["KR1", "KR2"],
+        "owners": ["user_123"],
+        "multiple_owners": False,
+        "date_created": 1702080000000,
+        "date_updated": 1702080000000,
+    }
+
+
+@pytest.fixture
+def sample_goal_list_data() -> dict:
+    """Sample goal list data for testing."""
+    return {
+        "items": [
+            {
+                "id": "goal_123",
+                "team_id": "team_001",
+                "name": "Q1 Revenue Goal",
+                "description": "Achieve $1M in revenue",
+                "due_date": 1702080000000,
+                "status": "active",
+                "key_results": ["KR1", "KR2"],
+                "owners": ["user_123"],
+                "multiple_owners": False,
+            },
+            {
+                "id": "goal_124",
+                "team_id": "team_001",
+                "name": "Q2 Revenue Goal",
+                "description": "Achieve $2M in revenue",
+                "due_date": 1702080000000,
+                "status": "active",
+                "key_results": ["KR3"],
+                "owners": ["user_123"],
+                "multiple_owners": False,
+            },
+        ],
+        "next_page": "cursor=2",
+        "total": 10,
+    }
+
+
+class TestGoalAPI:
+    """Test cases for GoalAPI."""
+
+    @pytest.mark.asyncio
+    async def test_create_goal(self, goal_api, mock_api_client, sample_goal_list_data):
+        """Test creating a goal."""
+        # Arrange
+        team_id = "team_001"
+        goal_create = GoalCreate(
+            name="Q1 Revenue Goal", description="Achieve $1M in revenue", due_date=1702080000000
+        )
+        mock_api_client.post.return_value = APIResponse(
+            success=True, status_code=200, data=sample_goal_list_data, headers={}
+        )
+
+        # Act
+        result = await goal_api.create(team_id, goal_create)
+
+        # Assert
+        mock_api_client.post.assert_called_once()
+        call_args = mock_api_client.post.call_args
+        assert call_args[0][0] == f"/team/{team_id}/goal"
+        assert isinstance(result, GoalListResponse)
+        assert len(result.items) == 2
+
+    @pytest.mark.asyncio
+    async def test_create_goal_returns_none_on_failure(self, goal_api, mock_api_client):
+        """Test creating a goal that fails returns None."""
+        # Arrange
+        team_id = "team_001"
+        goal_create = GoalCreate(
+            name="Q1 Revenue Goal", description="Achieve $1M in revenue", due_date=1702080000000
+        )
+        mock_api_client.post.return_value = APIResponse(
+            success=False, status_code=400, data={"err": "Invalid request"}, headers={}
+        )
+
+        # Act
+        result = await goal_api.create(team_id, goal_create)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_goal(self, goal_api, mock_api_client, sample_goal_data):
+        """Test getting a goal by ID."""
+        # Arrange
+        goal_id = "goal_123"
+        mock_api_client.get.return_value = APIResponse(
+            success=True, status_code=200, data=sample_goal_data, headers={}
+        )
+
+        # Act
+        result = await goal_api.get(goal_id)
+
+        # Assert
+        mock_api_client.get.assert_called_once_with(f"/goal/{goal_id}")
+        assert result is not None
+        assert result["id"] == "goal_123"
+
+    @pytest.mark.asyncio
+    async def test_get_goal_returns_none_on_failure(self, goal_api, mock_api_client):
+        """Test getting a goal that fails returns None."""
+        # Arrange
+        goal_id = "goal_123"
+        mock_api_client.get.return_value = APIResponse(
+            success=False, status_code=404, data={"err": "Not found"}, headers={}
+        )
+
+        # Act
+        result = await goal_api.get(goal_id)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_update_goal(self, goal_api, mock_api_client, sample_goal_data):
+        """Test updating a goal."""
+        # Arrange
+        goal_id = "goal_123"
+        goal_update = GoalUpdate(name="Updated Goal Name")
+        mock_api_client.put.return_value = APIResponse(
+            success=True, status_code=200, data=sample_goal_data, headers={}
+        )
+
+        # Act
+        result = await goal_api.update(goal_id, goal_update)
+
+        # Assert
+        mock_api_client.put.assert_called_once()
+        call_args = mock_api_client.put.call_args
+        assert call_args[0][0] == f"/goal/{goal_id}"
+        assert result is not None
+        assert result["id"] == "goal_123"
+
+    @pytest.mark.asyncio
+    async def test_update_goal_returns_none_on_failure(self, goal_api, mock_api_client):
+        """Test updating a goal that fails returns None."""
+        # Arrange
+        goal_id = "goal_123"
+        goal_update = GoalUpdate(name="Updated Goal Name")
+        mock_api_client.put.return_value = APIResponse(
+            success=False, status_code=400, data={"err": "Invalid request"}, headers={}
+        )
+
+        # Act
+        result = await goal_api.update(goal_id, goal_update)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_delete_goal(self, goal_api, mock_api_client):
+        """Test deleting a goal."""
+        # Arrange
+        goal_id = "goal_123"
+        mock_api_client.delete.return_value = APIResponse(
+            success=True, status_code=200, data=None, headers={}
+        )
+
+        # Act
+        result = await goal_api.delete(goal_id)
+
+        # Assert
+        mock_api_client.delete.assert_called_once_with(f"/goal/{goal_id}")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_delete_goal_returns_false_on_failure(self, goal_api, mock_api_client):
+        """Test deleting a goal that fails returns False."""
+        # Arrange
+        goal_id = "goal_123"
+        mock_api_client.delete.return_value = APIResponse(
+            success=False, status_code=404, data={"err": "Not found"}, headers={}
+        )
+
+        # Act
+        result = await goal_api.delete(goal_id)
+
+        # Assert
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_list_goals(self, goal_api, mock_api_client, sample_goal_list_data):
+        """Test listing goals with query parameters."""
+        # Arrange
+        team_id = "team_001"
+        query = GoalListQuery(status="active", limit=50)
+        mock_api_client.get.return_value = APIResponse(
+            success=True, status_code=200, data=sample_goal_list_data, headers={}
+        )
+
+        # Act
+        result = await goal_api.list(team_id, query)
+
+        # Assert
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == f"/team/{team_id}/goal"
+        assert isinstance(result, GoalListResponse)
+        assert len(result.items) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_goals_returns_none_on_failure(self, goal_api, mock_api_client):
+        """Test listing goals that fails returns None."""
+        # Arrange
+        team_id = "team_001"
+        query = GoalListQuery(status="active", limit=50)
+        mock_api_client.get.return_value = APIResponse(
+            success=False, status_code=400, data={"err": "Invalid request"}, headers={}
+        )
+
+        # Act
+        result = await goal_api.list(team_id, query)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_list_goals_with_filters(self, goal_api, mock_api_client, sample_goal_list_data):
+        """Test listing goals with multiple filters."""
+        # Arrange
+        team_id = "team_001"
+        query = GoalListQuery(
+            status="active", owner="user_123", start_date=1702080000000, end_date=1702083600000
+        )
+        mock_api_client.get.return_value = APIResponse(
+            success=True, status_code=200, data=sample_goal_list_data, headers={}
+        )
+
+        # Act
+        result = await goal_api.list(team_id, query)
+
+        # Assert
+        call_args = mock_api_client.get.call_args
+        assert call_args[1]["params"]["status"] == "active"
+        assert call_args[1]["params"]["owner"] == "user_123"
+        assert call_args[1]["params"]["start_date"] == 1702080000000
+        assert call_args[1]["params"]["end_date"] == 1702083600000
+        assert isinstance(result, GoalListResponse)

--- a/test/unit_test/api/test_task.py
+++ b/test/unit_test/api/test_task.py
@@ -435,9 +435,7 @@ class TestTaskAPI(BaseAPIClientTestSuite):
         """Test searching tasks with query parameters."""
         # Arrange
         query = {"team_id": "team_123", "query": "urgent bugs"}
-        mock_api_client.get.return_value = APIResponse(
-            success=True, status_code=200, data=sample_task_data, headers={}
-        )
+        mock_api_client.get.return_value = APIResponse(success=True, status_code=200, data=sample_task_data, headers={})
 
         # Act
         result = await task_api.search(query)
@@ -459,9 +457,7 @@ class TestTaskAPI(BaseAPIClientTestSuite):
             "priorities": [1, 2],
             "statuses": ["open", "in progress"],
         }
-        mock_api_client.get.return_value = APIResponse(
-            success=True, status_code=200, data=sample_task_data, headers={}
-        )
+        mock_api_client.get.return_value = APIResponse(success=True, status_code=200, data=sample_task_data, headers={})
 
         # Act
         result = await task_api.search(query)
@@ -502,9 +498,7 @@ class TestTaskAPI(BaseAPIClientTestSuite):
         """Test searching with empty data returns None."""
         # Arrange
         query = {"team_id": "team_123", "query": "urgent bugs"}
-        mock_api_client.get.return_value = APIResponse(
-            success=True, status_code=200, data=None, headers={}
-        )
+        mock_api_client.get.return_value = APIResponse(success=True, status_code=200, data=None, headers={})
 
         # Act
         result = await task_api.search(query)

--- a/test/unit_test/api/test_task.py
+++ b/test/unit_test/api/test_task.py
@@ -337,3 +337,95 @@ class TestTaskAPI(BaseAPIClientTestSuite):
 
         # Assert
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_add_assignee(self, task_api, mock_api_client):
+        """Test adding an assignee to a task."""
+        # Arrange
+        task_id = "task_123"
+        assignee_id = 42
+        mock_api_client.post.return_value = APIResponse(success=True, status_code=204, data=None, headers={})
+
+        # Act
+        result = await task_api.add_assignee(task_id, assignee_id)
+
+        # Assert
+        mock_api_client.post.assert_called_once_with(f"/task/{task_id}/member/{assignee_id}")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_add_assignee_with_string_id(self, task_api, mock_api_client):
+        """Test adding an assignee with string user ID."""
+        # Arrange
+        task_id = "task_123"
+        assignee_id = "user_abc"
+        mock_api_client.post.return_value = APIResponse(success=True, status_code=204, data=None, headers={})
+
+        # Act
+        result = await task_api.add_assignee(task_id, assignee_id)
+
+        # Assert
+        mock_api_client.post.assert_called_once_with(f"/task/{task_id}/member/{assignee_id}")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_add_assignee_returns_false_on_failure(self, task_api, mock_api_client):
+        """Test adding an assignee that fails returns False."""
+        # Arrange
+        task_id = "task_123"
+        assignee_id = 42
+        mock_api_client.post.return_value = APIResponse(
+            success=False, status_code=404, data={"err": "Task not found"}, headers={}
+        )
+
+        # Act
+        result = await task_api.add_assignee(task_id, assignee_id)
+
+        # Assert
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_remove_assignee(self, task_api, mock_api_client):
+        """Test removing an assignee from a task."""
+        # Arrange
+        task_id = "task_123"
+        assignee_id = 42
+        mock_api_client.delete.return_value = APIResponse(success=True, status_code=204, data=None, headers={})
+
+        # Act
+        result = await task_api.remove_assignee(task_id, assignee_id)
+
+        # Assert
+        mock_api_client.delete.assert_called_once_with(f"/task/{task_id}/member/{assignee_id}")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_remove_assignee_with_string_id(self, task_api, mock_api_client):
+        """Test removing an assignee with string user ID."""
+        # Arrange
+        task_id = "task_123"
+        assignee_id = "user_abc"
+        mock_api_client.delete.return_value = APIResponse(success=True, status_code=204, data=None, headers={})
+
+        # Act
+        result = await task_api.remove_assignee(task_id, assignee_id)
+
+        # Assert
+        mock_api_client.delete.assert_called_once_with(f"/task/{task_id}/member/{assignee_id}")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_remove_assignee_returns_false_on_failure(self, task_api, mock_api_client):
+        """Test removing an assignee that fails returns False."""
+        # Arrange
+        task_id = "task_123"
+        assignee_id = 42
+        mock_api_client.delete.return_value = APIResponse(
+            success=False, status_code=404, data={"err": "Task not found"}, headers={}
+        )
+
+        # Act
+        result = await task_api.remove_assignee(task_id, assignee_id)
+
+        # Assert
+        assert result is False

--- a/test/unit_test/api/test_task.py
+++ b/test/unit_test/api/test_task.py
@@ -429,3 +429,85 @@ class TestTaskAPI(BaseAPIClientTestSuite):
 
         # Assert
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_search(self, task_api, mock_api_client, sample_task_data):
+        """Test searching tasks with query parameters."""
+        # Arrange
+        query = {"team_id": "team_123", "query": "urgent bugs"}
+        mock_api_client.get.return_value = APIResponse(
+            success=True, status_code=200, data=sample_task_data, headers={}
+        )
+
+        # Act
+        result = await task_api.search(query)
+
+        # Assert
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == "/team/team_123/task"
+        assert call_args[1]["params"] == query
+        assert isinstance(result, TaskResp)
+
+    @pytest.mark.asyncio
+    async def test_search_with_filters(self, task_api, mock_api_client, sample_task_data):
+        """Test searching tasks with multiple filters."""
+        # Arrange
+        query = {
+            "team_id": "team_123",
+            "query": "urgent bugs",
+            "priorities": [1, 2],
+            "statuses": ["open", "in progress"],
+        }
+        mock_api_client.get.return_value = APIResponse(
+            success=True, status_code=200, data=sample_task_data, headers={}
+        )
+
+        # Act
+        result = await task_api.search(query)
+
+        # Assert
+        call_args = mock_api_client.get.call_args
+        assert call_args[1]["params"]["priorities"] == [1, 2]
+        assert call_args[1]["params"]["statuses"] == ["open", "in progress"]
+        assert isinstance(result, TaskResp)
+
+    @pytest.mark.asyncio
+    async def test_search_without_team_id_raises(self, task_api, mock_api_client):
+        """Test searching without team_id raises ValueError."""
+        # Arrange
+        query = {"query": "urgent bugs"}
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="team_id is required for search"):
+            await task_api.search(query)
+
+    @pytest.mark.asyncio
+    async def test_search_returns_none_on_failure(self, task_api, mock_api_client):
+        """Test searching that fails returns None."""
+        # Arrange
+        query = {"team_id": "team_123", "query": "urgent bugs"}
+        mock_api_client.get.return_value = APIResponse(
+            success=False, status_code=404, data={"err": "Team not found"}, headers={}
+        )
+
+        # Act
+        result = await task_api.search(query)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_search_with_empty_data_returns_none(self, task_api, mock_api_client):
+        """Test searching with empty data returns None."""
+        # Arrange
+        query = {"team_id": "team_123", "query": "urgent bugs"}
+        mock_api_client.get.return_value = APIResponse(
+            success=True, status_code=200, data=None, headers={}
+        )
+
+        # Act
+        result = await task_api.search(query)
+
+        # Assert
+        assert result is None

--- a/test/unit_test/api/test_time.py
+++ b/test/unit_test/api/test_time.py
@@ -12,19 +12,20 @@ Tests the TimeAPI class methods including:
 - Get tracking status
 """
 
+from unittest.mock import MagicMock
+
 import pytest
-from unittest.mock import MagicMock, AsyncMock
 
 from clickup_mcp.api.time import TimeAPI
+from clickup_mcp.client import ClickUpAPIClient
 from clickup_mcp.models.dto.time import (
     TimeEntryCreate,
     TimeEntryListQuery,
-    TimeEntryUpdate,
-    TimeEntryResponse,
     TimeEntryListResponse,
+    TimeEntryResponse,
+    TimeEntryUpdate,
     TimeTrackingStatusResponse,
 )
-from clickup_mcp.client import ClickUpAPIClient
 from clickup_mcp.models.http import APIResponse
 
 
@@ -104,9 +105,7 @@ class TestTimeAPI:
         """Test creating a time entry."""
         # Arrange
         team_id = "team_001"
-        time_entry_create = TimeEntryCreate(
-            task_id="task_456", description="Implementation work", duration=3600000
-        )
+        time_entry_create = TimeEntryCreate(task_id="task_456", description="Implementation work", duration=3600000)
         mock_api_client.post.return_value = APIResponse(
             success=True, status_code=200, data=sample_time_entry_data, headers={}
         )
@@ -122,15 +121,11 @@ class TestTimeAPI:
         assert result.id == "entry_123"
 
     @pytest.mark.asyncio
-    async def test_create_time_entry_returns_none_on_failure(
-        self, time_api, mock_api_client
-    ):
+    async def test_create_time_entry_returns_none_on_failure(self, time_api, mock_api_client):
         """Test creating a time entry that fails returns None."""
         # Arrange
         team_id = "team_001"
-        time_entry_create = TimeEntryCreate(
-            task_id="task_456", description="Implementation work", duration=3600000
-        )
+        time_entry_create = TimeEntryCreate(task_id="task_456", description="Implementation work", duration=3600000)
         mock_api_client.post.return_value = APIResponse(
             success=False, status_code=400, data={"err": "Invalid request"}, headers={}
         )
@@ -155,16 +150,12 @@ class TestTimeAPI:
         result = await time_api.get(team_id, time_entry_id)
 
         # Assert
-        mock_api_client.get.assert_called_once_with(
-            f"/team/{team_id}/time_entries/{time_entry_id}"
-        )
+        mock_api_client.get.assert_called_once_with(f"/team/{team_id}/time_entries/{time_entry_id}")
         assert isinstance(result, TimeEntryResponse)
         assert result.id == "entry_123"
 
     @pytest.mark.asyncio
-    async def test_get_time_entry_returns_none_on_failure(
-        self, time_api, mock_api_client
-    ):
+    async def test_get_time_entry_returns_none_on_failure(self, time_api, mock_api_client):
         """Test getting a time entry that fails returns None."""
         # Arrange
         team_id = "team_001"
@@ -180,9 +171,7 @@ class TestTimeAPI:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_list_time_entries(
-        self, time_api, mock_api_client, sample_time_entry_list_data
-    ):
+    async def test_list_time_entries(self, time_api, mock_api_client, sample_time_entry_list_data):
         """Test listing time entries with query parameters."""
         # Arrange
         team_id = "team_001"
@@ -202,9 +191,7 @@ class TestTimeAPI:
         assert len(result.items) == 2
 
     @pytest.mark.asyncio
-    async def test_list_time_entries_returns_none_on_failure(
-        self, time_api, mock_api_client
-    ):
+    async def test_list_time_entries_returns_none_on_failure(self, time_api, mock_api_client):
         """Test listing time entries that fails returns None."""
         # Arrange
         team_id = "team_001"
@@ -240,9 +227,7 @@ class TestTimeAPI:
         assert isinstance(result, TimeEntryResponse)
 
     @pytest.mark.asyncio
-    async def test_update_time_entry_returns_none_on_failure(
-        self, time_api, mock_api_client
-    ):
+    async def test_update_time_entry_returns_none_on_failure(self, time_api, mock_api_client):
         """Test updating a time entry that fails returns None."""
         # Arrange
         team_id = "team_001"
@@ -264,23 +249,17 @@ class TestTimeAPI:
         # Arrange
         team_id = "team_001"
         time_entry_id = "entry_123"
-        mock_api_client.delete.return_value = APIResponse(
-            success=True, status_code=200, data=None, headers={}
-        )
+        mock_api_client.delete.return_value = APIResponse(success=True, status_code=200, data=None, headers={})
 
         # Act
         result = await time_api.delete(team_id, time_entry_id)
 
         # Assert
-        mock_api_client.delete.assert_called_once_with(
-            f"/team/{team_id}/time_entries/{time_entry_id}"
-        )
+        mock_api_client.delete.assert_called_once_with(f"/team/{team_id}/time_entries/{time_entry_id}")
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_delete_time_entry_returns_false_on_failure(
-        self, time_api, mock_api_client
-    ):
+    async def test_delete_time_entry_returns_false_on_failure(self, time_api, mock_api_client):
         """Test deleting a time entry that fails returns False."""
         # Arrange
         team_id = "team_001"
@@ -300,23 +279,17 @@ class TestTimeAPI:
         """Test starting time tracking for a task."""
         # Arrange
         task_id = "task_123"
-        mock_api_client.post.return_value = APIResponse(
-            success=True, status_code=200, data=None, headers={}
-        )
+        mock_api_client.post.return_value = APIResponse(success=True, status_code=200, data=None, headers={})
 
         # Act
         result = await time_api.start_tracking(task_id)
 
         # Assert
-        mock_api_client.post.assert_called_once_with(
-            f"/task/{task_id}/time_tracking/start"
-        )
+        mock_api_client.post.assert_called_once_with(f"/task/{task_id}/time_tracking/start")
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_start_tracking_returns_false_on_failure(
-        self, time_api, mock_api_client
-    ):
+    async def test_start_tracking_returns_false_on_failure(self, time_api, mock_api_client):
         """Test starting tracking that fails returns False."""
         # Arrange
         task_id = "task_123"
@@ -336,9 +309,7 @@ class TestTimeAPI:
         # Arrange
         task_id = "task_123"
         description = "Completed implementation"
-        mock_api_client.post.return_value = APIResponse(
-            success=True, status_code=200, data=None, headers={}
-        )
+        mock_api_client.post.return_value = APIResponse(success=True, status_code=200, data=None, headers={})
 
         # Act
         result = await time_api.stop_tracking(task_id, description)
@@ -355,9 +326,7 @@ class TestTimeAPI:
         """Test stopping tracking without description."""
         # Arrange
         task_id = "task_123"
-        mock_api_client.post.return_value = APIResponse(
-            success=True, status_code=200, data=None, headers={}
-        )
+        mock_api_client.post.return_value = APIResponse(success=True, status_code=200, data=None, headers={})
 
         # Act
         result = await time_api.stop_tracking(task_id)
@@ -370,9 +339,7 @@ class TestTimeAPI:
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_stop_tracking_returns_false_on_failure(
-        self, time_api, mock_api_client
-    ):
+    async def test_stop_tracking_returns_false_on_failure(self, time_api, mock_api_client):
         """Test stopping tracking that fails returns False."""
         # Arrange
         task_id = "task_123"
@@ -387,9 +354,7 @@ class TestTimeAPI:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_get_tracking_status(
-        self, time_api, mock_api_client, sample_tracking_status_data
-    ):
+    async def test_get_tracking_status(self, time_api, mock_api_client, sample_tracking_status_data):
         """Test getting time tracking status for a task."""
         # Arrange
         task_id = "task_123"
@@ -407,9 +372,7 @@ class TestTimeAPI:
         assert result.task_id == "task_123"
 
     @pytest.mark.asyncio
-    async def test_get_tracking_status_returns_none_on_failure(
-        self, time_api, mock_api_client
-    ):
+    async def test_get_tracking_status_returns_none_on_failure(self, time_api, mock_api_client):
         """Test getting tracking status that fails returns None."""
         # Arrange
         task_id = "task_123"

--- a/test/unit_test/api/test_time.py
+++ b/test/unit_test/api/test_time.py
@@ -1,0 +1,424 @@
+"""
+Unit tests for the Time API.
+
+Tests the TimeAPI class methods including:
+- Create time entry
+- Get time entry
+- List time entries
+- Update time entry
+- Delete time entry
+- Start tracking
+- Stop tracking
+- Get tracking status
+"""
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+from clickup_mcp.api.time import TimeAPI
+from clickup_mcp.models.dto.time import (
+    TimeEntryCreate,
+    TimeEntryListQuery,
+    TimeEntryUpdate,
+    TimeEntryResponse,
+    TimeEntryListResponse,
+    TimeTrackingStatusResponse,
+)
+from clickup_mcp.client import ClickUpAPIClient
+from clickup_mcp.models.http import APIResponse
+
+
+@pytest.fixture
+def mock_api_client() -> MagicMock:
+    """Create a mock API client."""
+    client = MagicMock(spec=ClickUpAPIClient)
+    return client
+
+
+@pytest.fixture
+def time_api(mock_api_client: MagicMock) -> TimeAPI:
+    """Create a TimeAPI instance with mock client."""
+    return TimeAPI(mock_api_client)
+
+
+@pytest.fixture
+def sample_time_entry_data() -> dict:
+    """Sample time entry data for testing."""
+    return {
+        "id": "entry_123",
+        "task_id": "task_456",
+        "user_id": 789,
+        "team_id": "team_001",
+        "description": "Implementation work",
+        "duration": 3600000,
+        "start": 1702080000000,
+        "end": 1702083600000,
+        "billable": False,
+    }
+
+
+@pytest.fixture
+def sample_time_entry_list_data() -> dict:
+    """Sample time entry list data for testing."""
+    return {
+        "items": [
+            {
+                "id": "entry_123",
+                "task_id": "task_456",
+                "user_id": 789,
+                "team_id": "team_001",
+                "description": "Implementation work",
+                "duration": 3600000,
+                "billable": False,
+            },
+            {
+                "id": "entry_124",
+                "task_id": "task_457",
+                "user_id": 789,
+                "team_id": "team_001",
+                "description": "Review work",
+                "duration": 1800000,
+                "billable": True,
+            },
+        ],
+        "next_page": "cursor=2",
+        "total": 10,
+    }
+
+
+@pytest.fixture
+def sample_tracking_status_data() -> dict:
+    """Sample tracking status data for testing."""
+    return {
+        "active": True,
+        "start": 1702080000000,
+        "task_id": "task_123",
+    }
+
+
+class TestTimeAPI:
+    """Test cases for TimeAPI."""
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry(self, time_api, mock_api_client, sample_time_entry_data):
+        """Test creating a time entry."""
+        # Arrange
+        team_id = "team_001"
+        time_entry_create = TimeEntryCreate(
+            task_id="task_456", description="Implementation work", duration=3600000
+        )
+        mock_api_client.post.return_value = APIResponse(
+            success=True, status_code=200, data=sample_time_entry_data, headers={}
+        )
+
+        # Act
+        result = await time_api.create(team_id, time_entry_create)
+
+        # Assert
+        mock_api_client.post.assert_called_once()
+        call_args = mock_api_client.post.call_args
+        assert call_args[0][0] == f"/team/{team_id}/time_entries"
+        assert isinstance(result, TimeEntryResponse)
+        assert result.id == "entry_123"
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_returns_none_on_failure(
+        self, time_api, mock_api_client
+    ):
+        """Test creating a time entry that fails returns None."""
+        # Arrange
+        team_id = "team_001"
+        time_entry_create = TimeEntryCreate(
+            task_id="task_456", description="Implementation work", duration=3600000
+        )
+        mock_api_client.post.return_value = APIResponse(
+            success=False, status_code=400, data={"err": "Invalid request"}, headers={}
+        )
+
+        # Act
+        result = await time_api.create(team_id, time_entry_create)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_time_entry(self, time_api, mock_api_client, sample_time_entry_data):
+        """Test getting a time entry by ID."""
+        # Arrange
+        team_id = "team_001"
+        time_entry_id = "entry_123"
+        mock_api_client.get.return_value = APIResponse(
+            success=True, status_code=200, data=sample_time_entry_data, headers={}
+        )
+
+        # Act
+        result = await time_api.get(team_id, time_entry_id)
+
+        # Assert
+        mock_api_client.get.assert_called_once_with(
+            f"/team/{team_id}/time_entries/{time_entry_id}"
+        )
+        assert isinstance(result, TimeEntryResponse)
+        assert result.id == "entry_123"
+
+    @pytest.mark.asyncio
+    async def test_get_time_entry_returns_none_on_failure(
+        self, time_api, mock_api_client
+    ):
+        """Test getting a time entry that fails returns None."""
+        # Arrange
+        team_id = "team_001"
+        time_entry_id = "entry_123"
+        mock_api_client.get.return_value = APIResponse(
+            success=False, status_code=404, data={"err": "Not found"}, headers={}
+        )
+
+        # Act
+        result = await time_api.get(team_id, time_entry_id)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries(
+        self, time_api, mock_api_client, sample_time_entry_list_data
+    ):
+        """Test listing time entries with query parameters."""
+        # Arrange
+        team_id = "team_001"
+        query = TimeEntryListQuery(task_id="task_456", limit=50)
+        mock_api_client.get.return_value = APIResponse(
+            success=True, status_code=200, data=sample_time_entry_list_data, headers={}
+        )
+
+        # Act
+        result = await time_api.list(team_id, query)
+
+        # Assert
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == f"/team/{team_id}/time_entries"
+        assert isinstance(result, TimeEntryListResponse)
+        assert len(result.items) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_returns_none_on_failure(
+        self, time_api, mock_api_client
+    ):
+        """Test listing time entries that fails returns None."""
+        # Arrange
+        team_id = "team_001"
+        query = TimeEntryListQuery(task_id="task_456", limit=50)
+        mock_api_client.get.return_value = APIResponse(
+            success=False, status_code=400, data={"err": "Invalid request"}, headers={}
+        )
+
+        # Act
+        result = await time_api.list(team_id, query)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry(self, time_api, mock_api_client, sample_time_entry_data):
+        """Test updating a time entry."""
+        # Arrange
+        team_id = "team_001"
+        time_entry_id = "entry_123"
+        time_entry_update = TimeEntryUpdate(duration=7200000)
+        mock_api_client.put.return_value = APIResponse(
+            success=True, status_code=200, data=sample_time_entry_data, headers={}
+        )
+
+        # Act
+        result = await time_api.update(team_id, time_entry_id, time_entry_update)
+
+        # Assert
+        mock_api_client.put.assert_called_once()
+        call_args = mock_api_client.put.call_args
+        assert call_args[0][0] == f"/team/{team_id}/time_entries/{time_entry_id}"
+        assert isinstance(result, TimeEntryResponse)
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_returns_none_on_failure(
+        self, time_api, mock_api_client
+    ):
+        """Test updating a time entry that fails returns None."""
+        # Arrange
+        team_id = "team_001"
+        time_entry_id = "entry_123"
+        time_entry_update = TimeEntryUpdate(duration=7200000)
+        mock_api_client.put.return_value = APIResponse(
+            success=False, status_code=400, data={"err": "Invalid request"}, headers={}
+        )
+
+        # Act
+        result = await time_api.update(team_id, time_entry_id, time_entry_update)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_delete_time_entry(self, time_api, mock_api_client):
+        """Test deleting a time entry."""
+        # Arrange
+        team_id = "team_001"
+        time_entry_id = "entry_123"
+        mock_api_client.delete.return_value = APIResponse(
+            success=True, status_code=200, data=None, headers={}
+        )
+
+        # Act
+        result = await time_api.delete(team_id, time_entry_id)
+
+        # Assert
+        mock_api_client.delete.assert_called_once_with(
+            f"/team/{team_id}/time_entries/{time_entry_id}"
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_delete_time_entry_returns_false_on_failure(
+        self, time_api, mock_api_client
+    ):
+        """Test deleting a time entry that fails returns False."""
+        # Arrange
+        team_id = "team_001"
+        time_entry_id = "entry_123"
+        mock_api_client.delete.return_value = APIResponse(
+            success=False, status_code=404, data={"err": "Not found"}, headers={}
+        )
+
+        # Act
+        result = await time_api.delete(team_id, time_entry_id)
+
+        # Assert
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_start_tracking(self, time_api, mock_api_client):
+        """Test starting time tracking for a task."""
+        # Arrange
+        task_id = "task_123"
+        mock_api_client.post.return_value = APIResponse(
+            success=True, status_code=200, data=None, headers={}
+        )
+
+        # Act
+        result = await time_api.start_tracking(task_id)
+
+        # Assert
+        mock_api_client.post.assert_called_once_with(
+            f"/task/{task_id}/time_tracking/start"
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_start_tracking_returns_false_on_failure(
+        self, time_api, mock_api_client
+    ):
+        """Test starting tracking that fails returns False."""
+        # Arrange
+        task_id = "task_123"
+        mock_api_client.post.return_value = APIResponse(
+            success=False, status_code=400, data={"err": "Invalid request"}, headers={}
+        )
+
+        # Act
+        result = await time_api.start_tracking(task_id)
+
+        # Assert
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_stop_tracking(self, time_api, mock_api_client):
+        """Test stopping time tracking for a task."""
+        # Arrange
+        task_id = "task_123"
+        description = "Completed implementation"
+        mock_api_client.post.return_value = APIResponse(
+            success=True, status_code=200, data=None, headers={}
+        )
+
+        # Act
+        result = await time_api.stop_tracking(task_id, description)
+
+        # Assert
+        mock_api_client.post.assert_called_once()
+        call_args = mock_api_client.post.call_args
+        assert call_args[0][0] == f"/task/{task_id}/time_tracking/stop"
+        assert call_args[1]["data"] == {"description": description}
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_stop_tracking_without_description(self, time_api, mock_api_client):
+        """Test stopping tracking without description."""
+        # Arrange
+        task_id = "task_123"
+        mock_api_client.post.return_value = APIResponse(
+            success=True, status_code=200, data=None, headers={}
+        )
+
+        # Act
+        result = await time_api.stop_tracking(task_id)
+
+        # Assert
+        mock_api_client.post.assert_called_once()
+        call_args = mock_api_client.post.call_args
+        assert call_args[0][0] == f"/task/{task_id}/time_tracking/stop"
+        assert call_args[1]["data"] is None
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_stop_tracking_returns_false_on_failure(
+        self, time_api, mock_api_client
+    ):
+        """Test stopping tracking that fails returns False."""
+        # Arrange
+        task_id = "task_123"
+        mock_api_client.post.return_value = APIResponse(
+            success=False, status_code=400, data={"err": "Invalid request"}, headers={}
+        )
+
+        # Act
+        result = await time_api.stop_tracking(task_id)
+
+        # Assert
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_get_tracking_status(
+        self, time_api, mock_api_client, sample_tracking_status_data
+    ):
+        """Test getting time tracking status for a task."""
+        # Arrange
+        task_id = "task_123"
+        mock_api_client.get.return_value = APIResponse(
+            success=True, status_code=200, data=sample_tracking_status_data, headers={}
+        )
+
+        # Act
+        result = await time_api.get_tracking_status(task_id)
+
+        # Assert
+        mock_api_client.get.assert_called_once_with(f"/task/{task_id}/time_tracking")
+        assert isinstance(result, TimeTrackingStatusResponse)
+        assert result.active is True
+        assert result.task_id == "task_123"
+
+    @pytest.mark.asyncio
+    async def test_get_tracking_status_returns_none_on_failure(
+        self, time_api, mock_api_client
+    ):
+        """Test getting tracking status that fails returns None."""
+        # Arrange
+        task_id = "task_123"
+        mock_api_client.get.return_value = APIResponse(
+            success=False, status_code=404, data={"err": "Not found"}, headers={}
+        )
+
+        # Act
+        result = await time_api.get_tracking_status(task_id)
+
+        # Assert
+        assert result is None

--- a/test/unit_test/api/test_workflow.py
+++ b/test/unit_test/api/test_workflow.py
@@ -9,16 +9,17 @@ Tests the WorkflowAPI class methods including:
 - List workflows
 """
 
-import pytest
 from unittest.mock import MagicMock
 
+import pytest
+
 from clickup_mcp.api.workflow import WorkflowAPI
+from clickup_mcp.client import ClickUpAPIClient
 from clickup_mcp.models.dto.workflow import (
     WorkflowCreate,
-    WorkflowUpdate,
     WorkflowListResponse,
+    WorkflowUpdate,
 )
-from clickup_mcp.client import ClickUpAPIClient
 
 
 @pytest.fixture
@@ -86,9 +87,7 @@ class TestWorkflowAPI:
         assert len(result.items) == 1
 
     @pytest.mark.asyncio
-    async def test_create_workflow_returns_none_on_failure(
-        self, workflow_api, mock_api_client
-    ):
+    async def test_create_workflow_returns_none_on_failure(self, workflow_api, mock_api_client):
         """Test creating a workflow that fails returns None."""
         # Arrange
         team_id = "team_001"
@@ -122,9 +121,7 @@ class TestWorkflowAPI:
         assert len(result.items) == 1
 
     @pytest.mark.asyncio
-    async def test_get_workflow_returns_none_on_failure(
-        self, workflow_api, mock_api_client
-    ):
+    async def test_get_workflow_returns_none_on_failure(self, workflow_api, mock_api_client):
         """Test getting a workflow that fails returns None."""
         # Arrange
         workflow_id = "wf_123"
@@ -154,9 +151,7 @@ class TestWorkflowAPI:
         assert isinstance(result, WorkflowListResponse)
 
     @pytest.mark.asyncio
-    async def test_update_workflow_returns_none_on_failure(
-        self, workflow_api, mock_api_client
-    ):
+    async def test_update_workflow_returns_none_on_failure(self, workflow_api, mock_api_client):
         """Test updating a workflow that fails returns None."""
         # Arrange
         workflow_id = "wf_123"
@@ -184,9 +179,7 @@ class TestWorkflowAPI:
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_delete_workflow_returns_false_on_failure(
-        self, workflow_api, mock_api_client
-    ):
+    async def test_delete_workflow_returns_false_on_failure(self, workflow_api, mock_api_client):
         """Test deleting a workflow that fails returns False."""
         # Arrange
         workflow_id = "wf_123"
@@ -216,9 +209,7 @@ class TestWorkflowAPI:
         assert len(result.items) == 1
 
     @pytest.mark.asyncio
-    async def test_list_workflows_with_pagination(
-        self, workflow_api, mock_api_client, sample_workflow_data
-    ):
+    async def test_list_workflows_with_pagination(self, workflow_api, mock_api_client, sample_workflow_data):
         """Test listing workflows with pagination parameters."""
         # Arrange
         team_id = "team_001"
@@ -233,9 +224,7 @@ class TestWorkflowAPI:
         assert call_args[1]["params"]["limit"] == "50"
 
     @pytest.mark.asyncio
-    async def test_list_workflows_with_active_filter(
-        self, workflow_api, mock_api_client, sample_workflow_data
-    ):
+    async def test_list_workflows_with_active_filter(self, workflow_api, mock_api_client, sample_workflow_data):
         """Test listing workflows with active status filter."""
         # Arrange
         team_id = "team_001"
@@ -249,9 +238,7 @@ class TestWorkflowAPI:
         assert call_args[1]["params"]["is_active"] == "true"
 
     @pytest.mark.asyncio
-    async def test_list_workflows_returns_none_on_failure(
-        self, workflow_api, mock_api_client
-    ):
+    async def test_list_workflows_returns_none_on_failure(self, workflow_api, mock_api_client):
         """Test listing workflows that fails returns None."""
         # Arrange
         team_id = "team_001"

--- a/test/unit_test/api/test_workflow.py
+++ b/test/unit_test/api/test_workflow.py
@@ -1,0 +1,264 @@
+"""
+Unit tests for the Workflow API.
+
+Tests the WorkflowAPI class methods including:
+- Create workflow
+- Get workflow
+- Update workflow
+- Delete workflow
+- List workflows
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from clickup_mcp.api.workflow import WorkflowAPI
+from clickup_mcp.models.dto.workflow import (
+    WorkflowCreate,
+    WorkflowUpdate,
+    WorkflowListResponse,
+)
+from clickup_mcp.client import ClickUpAPIClient
+
+
+@pytest.fixture
+def mock_api_client() -> MagicMock:
+    """Create a mock API client."""
+    client = MagicMock(spec=ClickUpAPIClient)
+    return client
+
+
+@pytest.fixture
+def workflow_api(mock_api_client: MagicMock) -> WorkflowAPI:
+    """Create a WorkflowAPI instance with mock client."""
+    return WorkflowAPI(mock_api_client)
+
+
+@pytest.fixture
+def sample_workflow_data() -> dict:
+    """Sample workflow data for testing."""
+    return {
+        "items": [
+            {
+                "id": "wf_123",
+                "team_id": "team_001",
+                "name": "Auto-assign on create",
+                "description": "Automatically assign tasks on creation",
+                "trigger_type": "task_created",
+                "trigger_config": {"list_id": "456"},
+                "actions": [{"type": "assign", "user_id": "789"}],
+                "is_active": True,
+                "priority": 1,
+                "date_created": 1702080000000,
+                "date_updated": 1702080000000,
+            }
+        ],
+        "page": 0,
+        "limit": 100,
+        "total": 1,
+    }
+
+
+class TestWorkflowAPI:
+    """Test cases for WorkflowAPI."""
+
+    @pytest.mark.asyncio
+    async def test_create_workflow(self, workflow_api, mock_api_client, sample_workflow_data):
+        """Test creating a workflow automation."""
+        # Arrange
+        team_id = "team_001"
+        workflow_create = WorkflowCreate(
+            name="Auto-assign on create",
+            trigger_type="task_created",
+            trigger_config={"list_id": "456"},
+            actions=[{"type": "assign", "user_id": "789"}],
+        )
+        mock_api_client.post.return_value = {"data": sample_workflow_data}
+
+        # Act
+        result = await workflow_api.create(team_id, workflow_create)
+
+        # Assert
+        mock_api_client.post.assert_called_once()
+        call_args = mock_api_client.post.call_args
+        assert call_args[0][0] == f"/team/{team_id}/workflow"
+        assert isinstance(result, WorkflowListResponse)
+        assert len(result.items) == 1
+
+    @pytest.mark.asyncio
+    async def test_create_workflow_returns_none_on_failure(
+        self, workflow_api, mock_api_client
+    ):
+        """Test creating a workflow that fails returns None."""
+        # Arrange
+        team_id = "team_001"
+        workflow_create = WorkflowCreate(
+            name="Auto-assign on create",
+            trigger_type="task_created",
+            trigger_config={"list_id": "456"},
+            actions=[{"type": "assign", "user_id": "789"}],
+        )
+        mock_api_client.post.return_value = None
+
+        # Act
+        result = await workflow_api.create(team_id, workflow_create)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_workflow(self, workflow_api, mock_api_client, sample_workflow_data):
+        """Test getting a workflow by ID."""
+        # Arrange
+        workflow_id = "wf_123"
+        mock_api_client.get.return_value = {"data": sample_workflow_data}
+
+        # Act
+        result = await workflow_api.get(workflow_id)
+
+        # Assert
+        mock_api_client.get.assert_called_once_with(f"/workflow/{workflow_id}")
+        assert isinstance(result, WorkflowListResponse)
+        assert len(result.items) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_workflow_returns_none_on_failure(
+        self, workflow_api, mock_api_client
+    ):
+        """Test getting a workflow that fails returns None."""
+        # Arrange
+        workflow_id = "wf_123"
+        mock_api_client.get.return_value = None
+
+        # Act
+        result = await workflow_api.get(workflow_id)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_update_workflow(self, workflow_api, mock_api_client, sample_workflow_data):
+        """Test updating a workflow."""
+        # Arrange
+        workflow_id = "wf_123"
+        workflow_update = WorkflowUpdate(name="Updated name", is_active=False)
+        mock_api_client.put.return_value = {"data": sample_workflow_data}
+
+        # Act
+        result = await workflow_api.update(workflow_id, workflow_update)
+
+        # Assert
+        mock_api_client.put.assert_called_once()
+        call_args = mock_api_client.put.call_args
+        assert call_args[0][0] == f"/workflow/{workflow_id}"
+        assert isinstance(result, WorkflowListResponse)
+
+    @pytest.mark.asyncio
+    async def test_update_workflow_returns_none_on_failure(
+        self, workflow_api, mock_api_client
+    ):
+        """Test updating a workflow that fails returns None."""
+        # Arrange
+        workflow_id = "wf_123"
+        workflow_update = WorkflowUpdate(name="Updated name")
+        mock_api_client.put.return_value = None
+
+        # Act
+        result = await workflow_api.update(workflow_id, workflow_update)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_delete_workflow(self, workflow_api, mock_api_client):
+        """Test deleting a workflow."""
+        # Arrange
+        workflow_id = "wf_123"
+        mock_api_client.delete.return_value = {"success": True}
+
+        # Act
+        result = await workflow_api.delete(workflow_id)
+
+        # Assert
+        mock_api_client.delete.assert_called_once_with(f"/workflow/{workflow_id}")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_delete_workflow_returns_false_on_failure(
+        self, workflow_api, mock_api_client
+    ):
+        """Test deleting a workflow that fails returns False."""
+        # Arrange
+        workflow_id = "wf_123"
+        mock_api_client.delete.return_value = None
+
+        # Act
+        result = await workflow_api.delete(workflow_id)
+
+        # Assert
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_list_workflows(self, workflow_api, mock_api_client, sample_workflow_data):
+        """Test listing workflows for a team."""
+        # Arrange
+        team_id = "team_001"
+        mock_api_client.get.return_value = {"data": sample_workflow_data}
+
+        # Act
+        result = await workflow_api.list(team_id)
+
+        # Assert
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == f"/team/{team_id}/workflow"
+        assert isinstance(result, WorkflowListResponse)
+        assert len(result.items) == 1
+
+    @pytest.mark.asyncio
+    async def test_list_workflows_with_pagination(
+        self, workflow_api, mock_api_client, sample_workflow_data
+    ):
+        """Test listing workflows with pagination parameters."""
+        # Arrange
+        team_id = "team_001"
+        mock_api_client.get.return_value = {"data": sample_workflow_data}
+
+        # Act
+        result = await workflow_api.list(team_id, page=1, limit=50)
+
+        # Assert
+        call_args = mock_api_client.get.call_args
+        assert call_args[1]["params"]["page"] == "1"
+        assert call_args[1]["params"]["limit"] == "50"
+
+    @pytest.mark.asyncio
+    async def test_list_workflows_with_active_filter(
+        self, workflow_api, mock_api_client, sample_workflow_data
+    ):
+        """Test listing workflows with active status filter."""
+        # Arrange
+        team_id = "team_001"
+        mock_api_client.get.return_value = {"data": sample_workflow_data}
+
+        # Act
+        result = await workflow_api.list(team_id, is_active=True)
+
+        # Assert
+        call_args = mock_api_client.get.call_args
+        assert call_args[1]["params"]["is_active"] == "true"
+
+    @pytest.mark.asyncio
+    async def test_list_workflows_returns_none_on_failure(
+        self, workflow_api, mock_api_client
+    ):
+        """Test listing workflows that fails returns None."""
+        # Arrange
+        team_id = "team_001"
+        mock_api_client.get.return_value = None
+
+        # Act
+        result = await workflow_api.list(team_id)
+
+        # Assert
+        assert result is None

--- a/test/unit_test/mcp_server/test_workspace.py
+++ b/test/unit_test/mcp_server/test_workspace.py
@@ -318,9 +318,7 @@ async def test_workspace_create_with_special_characters(mock_get_client: MagicMo
     """Test creating a workspace with special characters in name."""
     # Test data
     workspace_id: str = "9018752317"
-    mock_workspace_resp: WorkspaceResp = WorkspaceResp(
-        id=workspace_id, name="Team @#$%^&*()", color="#3498db"
-    )
+    mock_workspace_resp: WorkspaceResp = WorkspaceResp(id=workspace_id, name="Team @#$%^&*()", color="#3498db")
 
     # Set up mocks
     mock_client: MagicMock = MagicMock()
@@ -344,9 +342,7 @@ async def test_workspace_create_with_long_name(mock_get_client: MagicMock) -> No
     # Test data
     workspace_id: str = "9018752317"
     long_name = "A" * 200
-    mock_workspace_resp: WorkspaceResp = WorkspaceResp(
-        id=workspace_id, name=long_name, color="#3498db"
-    )
+    mock_workspace_resp: WorkspaceResp = WorkspaceResp(id=workspace_id, name=long_name, color="#3498db")
 
     # Set up mocks
     mock_client: MagicMock = MagicMock()
@@ -370,9 +366,7 @@ async def test_workspace_create_with_invalid_color_format(mock_get_client: Magic
     # Test data
     workspace_id: str = "9018752317"
     invalid_color = "not-a-valid-color"
-    mock_workspace_resp: WorkspaceResp = WorkspaceResp(
-        id=workspace_id, name="Engineering Team", color=invalid_color
-    )
+    mock_workspace_resp: WorkspaceResp = WorkspaceResp(id=workspace_id, name="Engineering Team", color=invalid_color)
 
     # Set up mocks
     mock_client: MagicMock = MagicMock()

--- a/test/unit_test/mcp_server/test_workspace.py
+++ b/test/unit_test/mcp_server/test_workspace.py
@@ -310,3 +310,109 @@ async def test_workspace_create_with_name_only(mock_get_client: MagicMock) -> No
     assert result.result.name == "Engineering Team"
     assert result.result.color is None
     assert result.result.avatar is None
+
+
+@pytest.mark.asyncio
+@patch("clickup_mcp.mcp_server.workspace.ClickUpAPIClientFactory.get")
+async def test_workspace_create_with_special_characters(mock_get_client: MagicMock) -> None:
+    """Test creating a workspace with special characters in name."""
+    # Test data
+    workspace_id: str = "9018752317"
+    mock_workspace_resp: WorkspaceResp = WorkspaceResp(
+        id=workspace_id, name="Team @#$%^&*()", color="#3498db"
+    )
+
+    # Set up mocks
+    mock_client: MagicMock = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.team.create_workspace = AsyncMock(return_value=mock_workspace_resp)
+    mock_get_client.return_value = mock_client
+
+    # Call the function
+    result = await workspace_create(WorkspaceCreateInput(name="Team @#$%^&*()", color="#3498db"))
+
+    # Assertions
+    assert result.ok is True
+    assert result.result.name == "Team @#$%^&*()"
+
+
+@pytest.mark.asyncio
+@patch("clickup_mcp.mcp_server.workspace.ClickUpAPIClientFactory.get")
+async def test_workspace_create_with_long_name(mock_get_client: MagicMock) -> None:
+    """Test creating a workspace with a very long name."""
+    # Test data
+    workspace_id: str = "9018752317"
+    long_name = "A" * 200
+    mock_workspace_resp: WorkspaceResp = WorkspaceResp(
+        id=workspace_id, name=long_name, color="#3498db"
+    )
+
+    # Set up mocks
+    mock_client: MagicMock = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.team.create_workspace = AsyncMock(return_value=mock_workspace_resp)
+    mock_get_client.return_value = mock_client
+
+    # Call the function
+    result = await workspace_create(WorkspaceCreateInput(name=long_name, color="#3498db"))
+
+    # Assertions
+    assert result.ok is True
+    assert result.result.name == long_name
+
+
+@pytest.mark.asyncio
+@patch("clickup_mcp.mcp_server.workspace.ClickUpAPIClientFactory.get")
+async def test_workspace_create_with_invalid_color_format(mock_get_client: MagicMock) -> None:
+    """Test creating a workspace with invalid color format (should be passed through to API)."""
+    # Test data
+    workspace_id: str = "9018752317"
+    invalid_color = "not-a-valid-color"
+    mock_workspace_resp: WorkspaceResp = WorkspaceResp(
+        id=workspace_id, name="Engineering Team", color=invalid_color
+    )
+
+    # Set up mocks
+    mock_client: MagicMock = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.team.create_workspace = AsyncMock(return_value=mock_workspace_resp)
+    mock_get_client.return_value = mock_client
+
+    # Call the function
+    result = await workspace_create(WorkspaceCreateInput(name="Engineering Team", color=invalid_color))
+
+    # Assertions - the API may reject this, but our layer should pass it through
+    assert result.ok is True
+    assert result.result.color == invalid_color
+
+
+@pytest.mark.asyncio
+@patch("clickup_mcp.mcp_server.workspace.ClickUpAPIClientFactory.get")
+async def test_workspace_list_with_multiple_workspaces(mock_get_client: MagicMock) -> None:
+    """Test listing multiple workspaces."""
+    # Test data
+    mock_teams = [
+        WorkspaceResp(id="9018752317", name="Engineering Team", color="#3498db"),
+        WorkspaceResp(id="9018752318", name="Marketing Team", color="#e74c3c"),
+        WorkspaceResp(id="9018752319", name="Sales Team", color="#2ecc71"),
+    ]
+
+    # Set up mocks
+    mock_client: MagicMock = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.team.get_authorized_teams = AsyncMock(return_value=mock_teams)
+    mock_get_client.return_value = mock_client
+
+    # Call the function
+    result = await workspace_list()
+
+    # Assertions
+    assert result.ok is True
+    assert len(result.result.items) == 3
+    assert result.result.items[0].name == "Engineering Team"
+    assert result.result.items[1].name == "Marketing Team"
+    assert result.result.items[2].name == "Sales Team"


### PR DESCRIPTION
## Linked Task
Task 7.11

## Description
Add comprehensive user journey examples demonstrating common workflows when using the ClickUp MCP Server.

## Changes
- Add user-journeys.mdx to quick-start documentation
- Include 8 practical user journey examples:
  - Task Management Workflow
  - Goal and Key Result Management
  - Workflow Automation Setup
  - Time Tracking and Reporting
  - Analytics and Insights
  - Workspace and Project Setup
  - Custom Field Management
  - Task Dependencies
- Add best practices section covering error handling, pagination, and rate limiting

## Testing
All examples follow the MCP tool patterns and include proper error handling, pagination, and rate limiting considerations.